### PR TITLE
Phase 0: wire TBAAPI, scaffold Core Data removal, bump to iOS 26

### DIFF
--- a/Packages/TBAAPI/Package.swift
+++ b/Packages/TBAAPI/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.1
+// swift-tools-version: 6.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,8 +6,8 @@ import PackageDescription
 let package = Package(
     name: "TBAAPI",
     platforms: [
-        .iOS(.v18),
-        .macOS(.v15),
+        .iOS(.v26),
+        .macOS(.v26),
     ],
     products: [
         .library(

--- a/the-blue-alliance-ios.xcodeproj/project.pbxproj
+++ b/the-blue-alliance-ios.xcodeproj/project.pbxproj
@@ -80,6 +80,9 @@
 		927309A423DC0F26006145E0 /* TBA Spotlight Index Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 9273099C23DC0F26006145E0 /* TBA Spotlight Index Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		927309AC23DC0F68006145E0 /* IndexRequestHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 927309AA23DC0F68006145E0 /* IndexRequestHandler.swift */; };
 		927309B223DD1E66006145E0 /* HandoffService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 927309B123DD1E66006145E0 /* HandoffService.swift */; };
+		5EC0D41A2C26041600000002 /* LegacyCoreDataCleanup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26041600000001 /* LegacyCoreDataCleanup.swift */; };
+		5EC0D41A2C26041600000008 /* TBAAPI+App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26041600000007 /* TBAAPI+App.swift */; };
+		5EC0D41A2C26041600000004 /* MyTBALocalStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26041600000003 /* MyTBALocalStore.swift */; };
 		9274E14121B1026900F5D5D0 /* NotificationsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9274E14021B1026900F5D5D0 /* NotificationsViewController.swift */; };
 		9274E14521B10DA000F5D5D0 /* NotificationStatusTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9274E14421B10DA000F5D5D0 /* NotificationStatusTableViewCell.swift */; };
 		9274E14721B10DB700F5D5D0 /* NotificationStatusCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9274E14621B10DB700F5D5D0 /* NotificationStatusCellViewModel.swift */; };
@@ -341,6 +344,9 @@
 		927309AB23DC0F68006145E0 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		927309B023DCD69D006145E0 /* miket.gpx */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = miket.gpx; sourceTree = "<group>"; };
 		927309B123DD1E66006145E0 /* HandoffService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandoffService.swift; sourceTree = "<group>"; };
+		5EC0D41A2C26041600000001 /* LegacyCoreDataCleanup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyCoreDataCleanup.swift; sourceTree = "<group>"; };
+		5EC0D41A2C26041600000007 /* TBAAPI+App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TBAAPI+App.swift"; sourceTree = "<group>"; };
+		5EC0D41A2C26041600000003 /* MyTBALocalStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTBALocalStore.swift; sourceTree = "<group>"; };
 		9274E14021B1026900F5D5D0 /* NotificationsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsViewController.swift; sourceTree = "<group>"; };
 		9274E14421B10DA000F5D5D0 /* NotificationStatusTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationStatusTableViewCell.swift; sourceTree = "<group>"; };
 		9274E14621B10DB700F5D5D0 /* NotificationStatusCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationStatusCellViewModel.swift; sourceTree = "<group>"; };
@@ -1246,6 +1252,9 @@
 			isa = PBXGroup;
 			children = (
 				927309B123DD1E66006145E0 /* HandoffService.swift */,
+				5EC0D41A2C26041600000001 /* LegacyCoreDataCleanup.swift */,
+				5EC0D41A2C26041600000007 /* TBAAPI+App.swift */,
+				5EC0D41A2C26041600000003 /* MyTBALocalStore.swift */,
 				92BA25BF238F4E9000EC796D /* RemoteConfigService.swift */,
 				14F51703239AA70A00D9240F /* SearchService.swift */,
 				9255EB6C209AC9760006A745 /* RetryService.swift */,
@@ -1649,6 +1658,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				927309B223DD1E66006145E0 /* HandoffService.swift in Sources */,
+				5EC0D41A2C26041600000002 /* LegacyCoreDataCleanup.swift in Sources */,
+				5EC0D41A2C26041600000008 /* TBAAPI+App.swift in Sources */,
+				5EC0D41A2C26041600000004 /* MyTBALocalStore.swift in Sources */,
 				92A5E5DD21A22D550025CC85 /* Int16+Suffix.swift in Sources */,
 				514C2EF52F8F0D5F00C674A9 /* MatchBreakdownConfigurator2026.swift in Sources */,
 				92FF110E21A61AF6003BC5C4 /* EventInsightsViewController.swift in Sources */,
@@ -1879,7 +1891,7 @@
 				DEVELOPMENT_TEAM = "";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "spotlight-index/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1911,7 +1923,7 @@
 				DEVELOPMENT_TEAM = "";
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "spotlight-index/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1979,7 +1991,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -2035,7 +2047,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -2058,7 +2070,7 @@
 				DEVELOPMENT_TEAM = "";
 				EXCLUDED_ARCHS = "";
 				INFOPLIST_FILE = "the-blue-alliance-ios/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2083,7 +2095,7 @@
 				DEVELOPMENT_TEAM = "";
 				EXCLUDED_ARCHS = "";
 				INFOPLIST_FILE = "the-blue-alliance-ios/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2120,7 +2132,7 @@
 					"\"${PODS_ROOT}/Firebase/Core/Sources\"",
 				);
 				INFOPLIST_FILE = "tba-unit-tests/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2158,7 +2170,7 @@
 					"\"${PODS_ROOT}/Firebase/Core/Sources\"",
 				);
 				INFOPLIST_FILE = "tba-unit-tests/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/the-blue-alliance-ios/AppDelegate/AppDelegate.swift
+++ b/the-blue-alliance-ios/AppDelegate/AppDelegate.swift
@@ -9,6 +9,7 @@ import GoogleSignIn
 import MyTBAKit
 import Photos
 import Search
+import TBAAPI
 import TBAData
 import TBAKit
 import TBAUtils
@@ -59,7 +60,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private lazy var dependencies = Dependencies(errorRecorder: errorRecorder,
                                                  persistentContainer: persistentContainer,
                                                  tbaKit: tbaKit,
+                                                 api: api,
                                                  userDefaults: userDefaults)
+    // Owned here and passed explicitly to myTBA view controllers when they're
+    // migrated off Core Data — not in Dependencies, since only a handful of
+    // screens need them.
+    let favoritesStore = FavoritesStore()
+    let subscriptionsStore = SubscriptionsStore()
     private let errorRecorder = TBAErrorRecorder()
     lazy var indexDelegate: TBACoreDataCoreSpotlightDelegate = {
         let description = persistentContainer.persistentStoreDescriptions.first!
@@ -87,6 +94,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     let photoLibrary = PHPhotoLibrary.shared()
     lazy var remoteConfig: RemoteConfig = RemoteConfig.remoteConfig()
     var tbaKit: TBAKit!
+    var api: TBAAPI!
     let userDefaults: UserDefaults = UserDefaults.standard
     let urlOpener: URLOpener = UIApplication.shared
 
@@ -154,6 +162,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         let secrets = Secrets()
         tbaKit = TBAKit(apiKey: secrets.tbaAPIKey, userDefaults: userDefaults)
+        api = TBAAPI(apiKey: secrets.tbaAPIKey)
 
         // Listen for changes to FMS availability
         registerForFMSStatusChanges()

--- a/the-blue-alliance-ios/AppDelegate/Dependencies.swift
+++ b/the-blue-alliance-ios/AppDelegate/Dependencies.swift
@@ -1,5 +1,6 @@
 import CoreData
 import Foundation
+import TBAAPI
 import TBAKit
 import TBAUtils
 
@@ -7,12 +8,18 @@ class Dependencies {
     let errorRecorder: ErrorRecorder
     let persistentContainer: NSPersistentContainer
     let tbaKit: TBAKit
+    let api: TBAAPI
     let userDefaults: UserDefaults
 
-    init(errorRecorder: ErrorRecorder, persistentContainer: NSPersistentContainer, tbaKit: TBAKit, userDefaults: UserDefaults) {
+    init(errorRecorder: ErrorRecorder,
+         persistentContainer: NSPersistentContainer,
+         tbaKit: TBAKit,
+         api: TBAAPI,
+         userDefaults: UserDefaults) {
         self.errorRecorder = errorRecorder
         self.persistentContainer = persistentContainer
         self.tbaKit = tbaKit
+        self.api = api
         self.userDefaults = userDefaults
     }
 }

--- a/the-blue-alliance-ios/Services/LegacyCoreDataCleanup.swift
+++ b/the-blue-alliance-ios/Services/LegacyCoreDataCleanup.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+// One-shot removal of the legacy Core Data SQLite store from users upgrading
+// from the Core Data era of the app. Safe to call on every launch — the
+// `UserDefaults` flag short-circuits after a successful run.
+//
+// Not invoked yet — call site lands in AppDelegate in the Phase 7 cleanup,
+// after `TBAPersistenceContainer` is removed. Invoking it earlier is wasted
+// work: the Core Data stack would just recreate `TBA.sqlite` on launch.
+//
+// The legacy store lived in an app-group container (see below); older builds
+// may instead have written to the app's Application Support directory, so we
+// clear both.
+enum LegacyCoreDataCleanup {
+
+    private static let appGroupIdentifier = "group.com.the-blue-alliance.tba.tbadata"
+    private static let storeFilename = "TBA.sqlite"
+    private static let completedFlagKey = "has_removed_legacy_core_data_store_v1"
+
+    static func run(userDefaults: UserDefaults = .standard,
+                    fileManager: FileManager = .default) {
+        guard !userDefaults.bool(forKey: completedFlagKey) else { return }
+
+        for baseURL in legacyStoreBaseURLs(fileManager: fileManager) {
+            removeStoreFiles(at: baseURL, fileManager: fileManager)
+        }
+
+        userDefaults.set(true, forKey: completedFlagKey)
+    }
+
+    private static func legacyStoreBaseURLs(fileManager: FileManager) -> [URL] {
+        var urls: [URL] = []
+        if let groupURL = fileManager.containerURL(forSecurityApplicationGroupIdentifier: appGroupIdentifier) {
+            urls.append(groupURL)
+        }
+        urls.append(contentsOf: fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask))
+        return urls
+    }
+
+    private static func removeStoreFiles(at baseURL: URL, fileManager: FileManager) {
+        let storeURL = baseURL.appendingPathComponent(storeFilename)
+        let sidecarURLs = ["-wal", "-shm"].map { baseURL.appendingPathComponent(storeFilename + $0) }
+        for url in [storeURL] + sidecarURLs where fileManager.fileExists(atPath: url.path) {
+            try? fileManager.removeItem(at: url)
+        }
+    }
+}

--- a/the-blue-alliance-ios/Services/MyTBALocalStore.swift
+++ b/the-blue-alliance-ios/Services/MyTBALocalStore.swift
@@ -1,0 +1,74 @@
+import Foundation
+import MyTBAKit
+import Observation
+
+// Local mirrors of the user's MyTBA favorites and subscriptions. Stored as
+// Codable JSON in a single `Application Support/tba-myTBA/` directory so that
+// `MyTBALocalStore.wipeAll()` can trivially erase everything if the MyTBA
+// API shape ever changes.
+
+enum MyTBALocalStore {
+    static let directory: URL = {
+        let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? FileManager.default.temporaryDirectory
+        return base.appendingPathComponent("tba-myTBA", isDirectory: true)
+    }()
+
+    static func wipeAll() {
+        try? FileManager.default.removeItem(at: directory)
+    }
+}
+
+@Observable
+final class FavoritesStore {
+
+    private(set) var favorites: [MyTBAFavorite]
+    @ObservationIgnored private let fileURL: URL
+
+    init(fileURL: URL = MyTBALocalStore.directory.appendingPathComponent("favorites.json")) {
+        self.fileURL = fileURL
+        self.favorites = (try? Data(contentsOf: fileURL)).flatMap {
+            try? JSONDecoder().decode([MyTBAFavorite].self, from: $0)
+        } ?? []
+    }
+
+    func replaceAll(with favorites: [MyTBAFavorite]) {
+        self.favorites = favorites
+        try? FileManager.default.createDirectory(at: fileURL.deletingLastPathComponent(),
+                                                 withIntermediateDirectories: true)
+        guard let data = try? JSONEncoder().encode(favorites) else { return }
+        try? data.write(to: fileURL, options: .atomic)
+    }
+
+    func clear() {
+        favorites = []
+        try? FileManager.default.removeItem(at: fileURL)
+    }
+}
+
+@Observable
+final class SubscriptionsStore {
+
+    private(set) var subscriptions: [MyTBASubscription]
+    @ObservationIgnored private let fileURL: URL
+
+    init(fileURL: URL = MyTBALocalStore.directory.appendingPathComponent("subscriptions.json")) {
+        self.fileURL = fileURL
+        self.subscriptions = (try? Data(contentsOf: fileURL)).flatMap {
+            try? JSONDecoder().decode([MyTBASubscription].self, from: $0)
+        } ?? []
+    }
+
+    func replaceAll(with subscriptions: [MyTBASubscription]) {
+        self.subscriptions = subscriptions
+        try? FileManager.default.createDirectory(at: fileURL.deletingLastPathComponent(),
+                                                 withIntermediateDirectories: true)
+        guard let data = try? JSONEncoder().encode(subscriptions) else { return }
+        try? data.write(to: fileURL, options: .atomic)
+    }
+
+    func clear() {
+        subscriptions = []
+        try? FileManager.default.removeItem(at: fileURL)
+    }
+}

--- a/the-blue-alliance-ios/Services/TBAAPI+App.swift
+++ b/the-blue-alliance-ios/Services/TBAAPI+App.swift
@@ -1,0 +1,33 @@
+import Foundation
+import TBAAPI
+
+// App-facing error type for TBAAPI calls. Each wrapper translates the
+// generated `Operations.*.Output` enum into either a decoded body or a
+// `TBAAPIError`, so call sites only have to deal with async throws.
+enum TBAAPIError: Error {
+    case notModified
+    case unauthorized
+    case notFound
+    case unexpectedStatus(Int)
+}
+
+// Thin wrappers that hide the generated `Operations.*.Output` plumbing.
+// Each phase of the Core Data removal adds the wrappers it needs here.
+extension TBAAPI {
+
+    func eventsByYear(_ year: Int) async throws -> [Components.Schemas.Event] {
+        let response = try await client.getEventsByYear(path: .init(year: year))
+        switch response {
+        case .ok(let ok):
+            return try ok.body.json
+        case .notModified:
+            throw TBAAPIError.notModified
+        case .unauthorized:
+            throw TBAAPIError.unauthorized
+        case .notFound:
+            throw TBAAPIError.notFound
+        case .undocumented(let statusCode, _):
+            throw TBAAPIError.unexpectedStatus(statusCode)
+        }
+    }
+}


### PR DESCRIPTION
Foundations for the Core Data → TBAAPI migration. No behavior change yet; both the Core Data stack and TBAAPI are live in parallel.

- Bump main app deployment target to iOS 26
- Bump TBAAPI package to iOS 26 / macOS 26 (swift-tools 6.2)
- Add TBAAPI instance to Dependencies alongside the existing tbaKit
- Add LegacyCoreDataCleanup helper (Foundation-only wipe of the legacy TBA.sqlite in the app group + Application Support fallback). Not yet invoked — the call site lands in Phase 7 once TBAPersistenceContainer is removed, so the Core Data stack can't recreate the store after a wipe
- Add TBAAPI+App wrappers with a typed TBAAPIError + one example wrapper (eventsByYear) to establish the async/await unwrapping pattern
- Add MyTBALocalStore with FavoritesStore / SubscriptionsStore backed by Codable JSON files in Application Support/tba-myTBA/. Owned directly by AppDelegate (not Dependencies) so they only reach myTBA-related screens. MyTBALocalStore.wipeAll() removes the entire directory for future API shape changes