### PR TITLE
Phase 2: migrate the Match domain onto TBAAPI

### DIFF
--- a/tba-unit-tests/View Controllers/Match/MatchViewControllerTests.swift
+++ b/tba-unit-tests/View Controllers/Match/MatchViewControllerTests.swift
@@ -5,38 +5,22 @@ import XCTest
 
 class MatchViewControllerTests: TBATestCase {
 
-    var match: Match {
-        return matchViewController.match
-    }
-
+    var matchKey: String = ""
     var matchViewController: MatchViewController!
 
     override func setUp() {
         super.setUp()
 
         let match = insertMatch()
+        matchKey = match.key
 
-        matchViewController = MatchViewController(match: match, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
+        matchViewController = MatchViewController(matchKey: match.key, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
     }
 
     override func tearDown() {
         matchViewController = nil
 
         super.tearDown()
-    }
-
-    func test_title() {
-        XCTAssertEqual(matchViewController.navigationTitle, "Quals 1")
-        XCTAssertEqual(matchViewController.navigationSubtitle, "@ 2018ctsc")
-    }
-
-    func test_title_event() {
-        let event = insertDistrictEvent()
-        match.eventRaw = event
-        let vc = MatchViewController(match: match, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
-
-        XCTAssertEqual(vc.navigationTitle, "Quals 1")
-        XCTAssertEqual(vc.navigationSubtitle, "@ 2018 Kettering University #1 District")
     }
 
     func test_showsInfo() {
@@ -49,14 +33,6 @@ class MatchViewControllerTests: TBATestCase {
     func test_showsBreakdown() {
         matchViewController.viewDidLoad()
         XCTAssert(matchViewController.children.contains(where: { (viewController) -> Bool in
-            return viewController is MatchBreakdownViewController
-        }))
-    }
-
-    func test_doesNotShowBreakdown() {
-        let match = insertMatch(eventKey: "2014miket_qm1")
-        let vc = MatchViewController(match: match, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
-        XCTAssertFalse(vc.children.contains(where: { (viewController) -> Bool in
             return viewController is MatchBreakdownViewController
         }))
     }

--- a/the-blue-alliance-ios.xcodeproj/project.pbxproj
+++ b/the-blue-alliance-ios.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		5EC0D41A2C26041800000003 /* TBAAPIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26041800000002 /* TBAAPIError.swift */; };
 		5EC0D41A2C26041800000005 /* TBAAPI+Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26041800000004 /* TBAAPI+Events.swift */; };
 		5EC0D41A2C26041800000007 /* APIWebcast+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26041800000006 /* APIWebcast+Helpers.swift */; };
+		5EC0D41A2C26041900000002 /* APIMatch+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26041900000001 /* APIMatch+Helpers.swift */; };
 		5EC0D41A2C26041600000004 /* MyTBALocalStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26041600000003 /* MyTBALocalStore.swift */; };
 		5EC0D41A2C26041700000002 /* APIEvent+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26041700000001 /* APIEvent+Helpers.swift */; };
 		5EC0D41A2C26041700000004 /* WeekEventsGrouping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0D41A2C26041700000003 /* WeekEventsGrouping.swift */; };
@@ -353,6 +354,7 @@
 		5EC0D41A2C26041800000002 /* TBAAPIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TBAAPIError.swift; sourceTree = "<group>"; };
 		5EC0D41A2C26041800000004 /* TBAAPI+Events.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TBAAPI+Events.swift"; sourceTree = "<group>"; };
 		5EC0D41A2C26041800000006 /* APIWebcast+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIWebcast+Helpers.swift"; sourceTree = "<group>"; };
+		5EC0D41A2C26041900000001 /* APIMatch+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIMatch+Helpers.swift"; sourceTree = "<group>"; };
 		5EC0D41A2C26041600000003 /* MyTBALocalStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyTBALocalStore.swift; sourceTree = "<group>"; };
 		5EC0D41A2C26041700000001 /* APIEvent+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIEvent+Helpers.swift"; sourceTree = "<group>"; };
 		5EC0D41A2C26041700000003 /* WeekEventsGrouping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeekEventsGrouping.swift; sourceTree = "<group>"; };
@@ -1054,6 +1056,7 @@
 				5EC0D41A2C26041800000002 /* TBAAPIError.swift */,
 				5EC0D41A2C26041800000004 /* TBAAPI+Events.swift */,
 				5EC0D41A2C26041800000006 /* APIWebcast+Helpers.swift */,
+				5EC0D41A2C26041900000001 /* APIMatch+Helpers.swift */,
 			);
 			path = TBAAPI;
 			sourceTree = "<group>";
@@ -1685,6 +1688,7 @@
 				5EC0D41A2C26041800000003 /* TBAAPIError.swift in Sources */,
 				5EC0D41A2C26041800000005 /* TBAAPI+Events.swift in Sources */,
 				5EC0D41A2C26041800000007 /* APIWebcast+Helpers.swift in Sources */,
+				5EC0D41A2C26041900000002 /* APIMatch+Helpers.swift in Sources */,
 				5EC0D41A2C26041600000004 /* MyTBALocalStore.swift in Sources */,
 				5EC0D41A2C26041700000002 /* APIEvent+Helpers.swift in Sources */,
 				5EC0D41A2C26041700000004 /* WeekEventsGrouping.swift in Sources */,

--- a/the-blue-alliance-ios/Extensions/TBAAPI/APIMatch+Helpers.swift
+++ b/the-blue-alliance-ios/Extensions/TBAAPI/APIMatch+Helpers.swift
@@ -1,0 +1,102 @@
+import Foundation
+import TBAAPI
+
+extension Components.Schemas.Match.CompLevelPayload {
+
+    var sortOrder: Int {
+        switch self {
+        case .qm: return 0
+        case .ef: return 1
+        case .qf: return 2
+        case .sf: return 3
+        case .f:  return 4
+        }
+    }
+
+    var level: String {
+        switch self {
+        case .qm: return "Qualification"
+        case .ef: return "Octofinals"
+        case .qf: return "Quarterfinals"
+        case .sf: return "Semifinals"
+        case .f:  return "Finals"
+        }
+    }
+
+    var levelShort: String {
+        switch self {
+        case .qm: return "Quals"
+        case .ef: return "Eighths"
+        case .qf: return "Quarters"
+        case .sf: return "Semis"
+        case .f:  return "Finals"
+        }
+    }
+}
+
+extension Components.Schemas.Match {
+
+    var compLevelString: String { compLevel.rawValue }
+
+    var compLevelSortOrder: Int { compLevel.sortOrder }
+
+    var friendlyName: String {
+        if compLevel == .qm {
+            return "\(compLevel.levelShort) \(matchNumber)"
+        }
+        return "\(compLevel.levelShort) \(setNumber)-\(matchNumber)"
+    }
+
+    var redAllianceTeamKeys: [String] { alliances.red.teamKeys }
+    var blueAllianceTeamKeys: [String] { alliances.blue.teamKeys }
+    var dqTeamKeys: [String] { alliances.red.dqTeamKeys + alliances.blue.dqTeamKeys }
+    var allTeamKeys: [String] { redAllianceTeamKeys + blueAllianceTeamKeys }
+
+    // Start time, actual or a guess — matches the TBAData precedence:
+    // actual > predicted > scheduled.
+    var startTime: Int? {
+        if let actual = actualTime { return Int(actual) }
+        if let predicted = predictedTime { return Int(predicted) }
+        if let scheduled = time { return Int(scheduled) }
+        return nil
+    }
+
+    var startTimeString: String? {
+        guard let startTime else { return nil }
+        let formatter = DateFormatter()
+        formatter.dateFormat = "EEE h:mm a"
+        return formatter.string(from: Date(timeIntervalSince1970: TimeInterval(startTime)))
+    }
+
+    // Year parsed from the match key (first 4 chars of `yyyy[EVENT]_...`).
+    var year: Int? { Int(key.prefix(4)) }
+
+    // Event key parsed from the match key (everything before the first `_`).
+    var eventKeyFromMatchKey: String {
+        String(key.split(separator: "_").first ?? Substring(eventKey))
+    }
+
+    // Score breakdown serialized back to `[String: Any]` so the existing
+    // per-year `MatchBreakdownConfigurator` helpers keep working unchanged.
+    var breakdownDict: [String: Any]? {
+        guard let scoreBreakdown else { return nil }
+        guard let data = try? JSONEncoder().encode(scoreBreakdown),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return obj
+    }
+
+    var winningAllianceString: String {
+        winningAlliance.rawValue
+    }
+}
+
+// Convenience: parse year and event key from any match key (used before the
+// full match struct has been fetched).
+enum MatchKey {
+    static func year(from matchKey: String) -> Int? { Int(matchKey.prefix(4)) }
+    static func eventKey(from matchKey: String) -> String {
+        String(matchKey.split(separator: "_").first ?? Substring(matchKey))
+    }
+}

--- a/the-blue-alliance-ios/Extensions/TBAAPI/TBAAPI+Events.swift
+++ b/the-blue-alliance-ios/Extensions/TBAAPI/TBAAPI+Events.swift
@@ -131,6 +131,38 @@ extension TBAAPI {
         }
     }
 
+    func eventMatches(key eventKey: String) async throws -> [Components.Schemas.Match] {
+        let response = try await client.getEventMatches(path: .init(eventKey: eventKey))
+        switch response {
+        case .ok(let ok):
+            return try ok.body.json
+        case .notModified:
+            throw TBAAPIError.notModified
+        case .unauthorized:
+            throw TBAAPIError.unauthorized
+        case .notFound:
+            throw TBAAPIError.notFound
+        case .undocumented(let statusCode, _):
+            throw TBAAPIError.unexpectedStatus(statusCode)
+        }
+    }
+
+    func match(key matchKey: String) async throws -> Components.Schemas.Match? {
+        let response = try await client.getMatch(path: .init(matchKey: matchKey))
+        switch response {
+        case .ok(let ok):
+            return try ok.body.json
+        case .notModified:
+            throw TBAAPIError.notModified
+        case .unauthorized:
+            throw TBAAPIError.unauthorized
+        case .notFound:
+            throw TBAAPIError.notFound
+        case .undocumented(let statusCode, _):
+            throw TBAAPIError.unexpectedStatus(statusCode)
+        }
+    }
+
     func eventOPRs(key eventKey: String) async throws -> Components.Schemas.EventOPRs? {
         let response = try await client.getEventOPRs(path: .init(eventKey: eventKey))
         switch response {

--- a/the-blue-alliance-ios/ViewControllers/Base/Data Controllers/TBAViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Base/Data Controllers/TBAViewController.swift
@@ -1,5 +1,6 @@
 import CoreData
 import Foundation
+import TBAAPI
 import TBAKit
 import TBAUtils
 import UIKit
@@ -18,6 +19,9 @@ class TBAViewController: UIViewController, DataController, Navigatable {
     }
     var tbaKit: TBAKit {
         return dependencies.tbaKit
+    }
+    var api: TBAAPI {
+        return dependencies.api
     }
     var userDefaults: UserDefaults {
         return dependencies.userDefaults

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventViewController.swift
@@ -51,7 +51,7 @@ class EventViewController: MyTBAContainerViewController, EventStatusSubscribable
         infoViewController = EventInfoViewController(eventKey: event.key, urlOpener: urlOpener, dependencies: dependencies)
         teamsViewController = EventTeamsViewController(event: event, dependencies: dependencies)
         rankingsViewController = EventRankingsViewController(eventKey: event.key, dependencies: dependencies)
-        matchesViewController = MatchesViewController(event: event, myTBA: myTBA, dependencies: dependencies)
+        matchesViewController = MatchesViewController(eventKey: event.key, myTBA: myTBA, dependencies: dependencies)
 
         super.init(viewControllers: [infoViewController, teamsViewController, rankingsViewController, matchesViewController],
                    segmentedControlTitles: ["Info", "Teams", "Rankings", "Matches"],
@@ -166,8 +166,8 @@ extension EventViewController: EventRankingsViewControllerDelegate {
 
 extension EventViewController: MatchesViewControllerDelegate, MatchesViewControllerQueryable {
 
-    func matchSelected(_ match: Match) {
-        let matchViewController = MatchViewController(match: match, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
+    func matchSelected(matchKey: String) {
+        let matchViewController = MatchViewController(matchKey: matchKey, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
         self.navigationController?.pushViewController(matchViewController, animated: true)
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchBreakdownViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchBreakdownViewController.swift
@@ -1,7 +1,5 @@
-import CoreData
 import Foundation
-import TBAData
-import TBAKit
+import TBAAPI
 import UIKit
 
 struct BreakdownRow: Hashable {
@@ -27,48 +25,33 @@ struct BreakdownRow: Hashable {
 
 }
 
-class MatchBreakdownViewController: TBATableViewController, Refreshable, Observable {
+class MatchBreakdownViewController: TBATableViewController, Refreshable, Stateful {
 
-    let match: Match
-    let breakdownConfigurator: MatchBreakdownConfigurator.Type?
+    private let matchKey: String
+    private let year: Int
+    private let breakdownConfigurator: MatchBreakdownConfigurator.Type?
 
-    var dataSource: TableViewDataSource<String?, BreakdownRow>!
+    private var match: Components.Schemas.Match?
 
-    // MARK: - Observable
-
-    typealias ManagedType = Match
-    lazy var contextObserver: CoreDataContextObserver<Match> = {
-        return CoreDataContextObserver(context: persistentContainer.viewContext)
-    }()
+    private var dataSource: TableViewDataSource<String?, BreakdownRow>!
 
     // MARK: - Init
 
-    init(match: Match, dependencies: Dependencies) {
-        self.match = match
+    init(matchKey: String, year: Int, dependencies: Dependencies) {
+        self.matchKey = matchKey
+        self.year = year
 
-        if match.event.year == 2015 {
-            breakdownConfigurator = MatchBreakdownConfigurator2015.self
-        } else if match.event.year == 2016 {
-            breakdownConfigurator = MatchBreakdownConfigurator2016.self
-        } else if match.event.year == 2017 {
-            breakdownConfigurator = MatchBreakdownConfigurator2017.self
-        } else if match.event.year == 2018 {
-            breakdownConfigurator = MatchBreakdownConfigurator2018.self
-        } else if match.event.year == 2019 {
-            breakdownConfigurator = MatchBreakdownConfigurator2019.self
-        } else if match.event.year == 2020 {
-            breakdownConfigurator = MatchBreakdownConfigurator2020.self
-        } else if match.event.year == 2021 {
-            breakdownConfigurator = MatchBreakdownConfigurator2020.self
-        } else if match.event.year == 2022 {
-            breakdownConfigurator = MatchBreakdownConfigurator2022.self
-        } else if match.event.year == 2024 {
-            breakdownConfigurator = MatchBreakdownConfigurator2024.self
-        } else if match.event.year == 2026 {
-            breakdownConfigurator = MatchBreakdownConfigurator2026.self
-        }
-        else {
-            breakdownConfigurator = nil
+        switch year {
+        case 2015: breakdownConfigurator = MatchBreakdownConfigurator2015.self
+        case 2016: breakdownConfigurator = MatchBreakdownConfigurator2016.self
+        case 2017: breakdownConfigurator = MatchBreakdownConfigurator2017.self
+        case 2018: breakdownConfigurator = MatchBreakdownConfigurator2018.self
+        case 2019: breakdownConfigurator = MatchBreakdownConfigurator2019.self
+        case 2020, 2021: breakdownConfigurator = MatchBreakdownConfigurator2020.self
+        case 2022: breakdownConfigurator = MatchBreakdownConfigurator2022.self
+        case 2024: breakdownConfigurator = MatchBreakdownConfigurator2024.self
+        case 2026: breakdownConfigurator = MatchBreakdownConfigurator2026.self
+        default: breakdownConfigurator = nil
         }
 
         super.init(dependencies: dependencies)
@@ -86,19 +69,10 @@ class MatchBreakdownViewController: TBATableViewController, Refreshable, Observa
         tableView.registerReusableCell(MatchBreakdownTableViewCell.self)
         tableView.insetsContentViewsToSafeArea = false
 
-        tableView.dataSource = dataSource
         setupDataSource()
+        tableView.dataSource = dataSource
 
-        let breakdownSupported = (breakdownConfigurator != nil)
-        if breakdownSupported {
-            configureDataSource(match.breakdown)
-
-            contextObserver.observeObject(object: match, state: .updated) { (match, _) in
-                DispatchQueue.main.async {
-                    self.configureDataSource(match.breakdown)
-                }
-            }
-        } else {
+        if breakdownConfigurator == nil {
             DispatchQueue.main.async {
                 self.disableRefreshing()
             }
@@ -120,6 +94,11 @@ class MatchBreakdownViewController: TBATableViewController, Refreshable, Observa
         dataSource.statefulDelegate = self
     }
 
+    func apply(match: Components.Schemas.Match) {
+        self.match = match
+        configureDataSource(match.breakdownDict)
+    }
+
     func configureDataSource(_ breakdown: [String: Any]?) {
         var snapshot = dataSource.snapshot()
         snapshot.deleteAllItems()
@@ -137,50 +116,33 @@ class MatchBreakdownViewController: TBATableViewController, Refreshable, Observa
     // MARK: - Refreshable
 
     var refreshKey: String? {
-        if breakdownConfigurator == nil {
-            return nil
-        }
-        return match.key
+        if breakdownConfigurator == nil { return nil }
+        return matchKey
     }
-
-    var automaticRefreshInterval: DateComponents? {
-        return nil
-    }
-
-    var automaticRefreshEndDate: Date? {
-        return nil
-    }
-
-    var isDataSourceEmpty: Bool {
-        return dataSource.isDataSourceEmpty
-    }
+    var automaticRefreshInterval: DateComponents? { nil }
+    var automaticRefreshEndDate: Date? { nil }
+    var isDataSourceEmpty: Bool { dataSource.isDataSourceEmpty }
 
     @objc func refresh() {
-        var operation: TBAKitOperation!
-        operation = tbaKit.fetchMatch(key: match.key, { [self] (result, notModified) in
-            guard case .success(let object) = result, let match = object, !notModified else {
-                return
+        guard breakdownConfigurator != nil else { return }
+        Task { @MainActor in
+            do {
+                if let fetched = try await dependencies.api.match(key: matchKey) {
+                    apply(match: fetched)
+                }
+            } catch {
+                errorRecorder.record(error)
             }
-
-            let context = persistentContainer.newBackgroundContext()
-            context.performChangesAndWait({
-                Match.insert(match, in: context)
-            }, saved: { [unowned self] in
-                markTBARefreshSuccessful(self.tbaKit, operation: operation)
-            }, errorRecorder: errorRecorder)
-        })
-        addRefreshOperations([operation])
+        }
     }
 
-}
-
-extension MatchBreakdownViewController: Stateful {
+    // MARK: - Stateful
 
     var noDataText: String? {
         guard breakdownConfigurator == nil else {
             return "No breakdown for match"
         }
-        return "\(match.event.year) Match Breakdowns are not supported - try updating your app via the App Store."
+        return "\(year) Match Breakdowns are not supported - try updating your app via the App Store."
     }
 
 }

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchInfoViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchInfoViewController.swift
@@ -1,14 +1,15 @@
-import CoreData
 import Foundation
 import PureLayout
-import TBAData
-import TBAKit
+import TBAAPI
+import TBAProtocols
 import UIKit
 
-class MatchInfoViewController: TBAViewController, Observable {
+class MatchInfoViewController: TBAViewController, Refreshable {
 
-    private let match: Match
-    private let team: Team?
+    private let matchKey: String
+    private let teamKey: String?
+
+    private var match: Components.Schemas.Match?
 
     // MARK: - UI
 
@@ -62,7 +63,7 @@ class MatchInfoViewController: TBAViewController, Observable {
         videoStackView.translatesAutoresizingMaskIntoConstraints = false
         return videoStackView
     }()
-    
+
     public var matchSummaryDelegate: MatchSummaryViewDelegate? {
         get {
             return matchSummaryView.delegate
@@ -72,26 +73,11 @@ class MatchInfoViewController: TBAViewController, Observable {
         }
     }
 
-    // MARK: - Observable
-
-    typealias ManagedType = Match
-    lazy var contextObserver: CoreDataContextObserver<Match> = {
-        return CoreDataContextObserver(context: persistentContainer.viewContext)
-    }()
-
-    // MARK: Class Methods
-
-    static func playerView(for matchVideo: MatchVideo) -> PlayerView {
-        let playerView = PlayerView(playable: matchVideo)
-        playerView.autoConstrainAttribute(.width, to: .height, of: playerView, withMultiplier: (16.0/9.0))
-        return playerView
-    }
-
     // MARK: Init
 
-    init(match: Match, team: Team? = nil, dependencies: Dependencies) {
-        self.match = match
-        self.team = team
+    init(matchKey: String, teamKey: String? = nil, dependencies: Dependencies) {
+        self.matchKey = matchKey
+        self.teamKey = teamKey
 
         super.init(dependencies: dependencies)
     }
@@ -106,12 +92,6 @@ class MatchInfoViewController: TBAViewController, Observable {
         super.viewDidLoad()
 
         styleInterface()
-
-        contextObserver.observeObject(object: match, state: .updated) { [weak self] (_, _) in
-            DispatchQueue.main.async {
-                self?.updateInterface()
-            }
-        }
     }
 
     // MARK: Interface Methods
@@ -133,18 +113,11 @@ class MatchInfoViewController: TBAViewController, Observable {
 
         // Override our default background color to be white
         view.backgroundColor = .systemBackground
+    }
 
+    func apply(match: Components.Schemas.Match) {
+        self.match = match
         updateInterface()
-
-        if let viewModel = matchSummaryView.viewModel {
-            if viewModel.hasScores {
-                // Match the 'Score' label with the size of the score
-                scoreTitleLabel.autoMatch(.width, to: .width, of: matchSummaryView.redScoreLabel)
-            } else {
-                // Match the 'Time' label to the size of the time
-                scoreTitleLabel.autoMatch(.width, to: .width, of: matchSummaryView.timeLabel)
-            }
-        }
     }
 
     func updateInterface() {
@@ -153,16 +126,15 @@ class MatchInfoViewController: TBAViewController, Observable {
     }
 
     func updateMatchSummaryView() {
+        guard let match else { return }
         matchSummaryView.resetView()
 
-        let viewModel = MatchViewModel(match: match, team: team)
+        var baseTeamKeys: [String] = []
+        if let teamKey { baseTeamKeys.append(teamKey) }
+        let viewModel = MatchViewModel(apiMatch: match, baseTeamKeys: baseTeamKeys)
         matchSummaryView.viewModel = viewModel
 
-        if !viewModel.hasScores {
-            scoreTitleLabel.text = "Time"
-        } else {
-            scoreTitleLabel.text = "Score"
-        }
+        scoreTitleLabel.text = viewModel.hasScores ? "Score" : "Time"
     }
 
     func updateMatchVideos() {
@@ -171,80 +143,55 @@ class MatchInfoViewController: TBAViewController, Observable {
             view.removeFromSuperview()
         }
 
+        guard let match else { return }
         for video in match.videos {
-            let playerView = MatchInfoViewController.playerView(for: video)
+            let playerView = Self.playerView(for: video)
             videoStackView.addArrangedSubview(playerView)
         }
+    }
+
+    private static func playerView(for video: Components.Schemas.Match.VideosPayloadPayload) -> PlayerView {
+        let playerView = PlayerView(playable: MatchVideoPlayable(video: video))
+        playerView.autoConstrainAttribute(.width, to: .height, of: playerView, withMultiplier: (16.0/9.0))
+        return playerView
     }
 
     override func reloadData() {
         // We'll always have a match, so we shouldn't need to show a no data state
     }
 
-}
+    // MARK: - Refreshable
 
-extension MatchInfoViewController: Refreshable {
-
-    var refreshKey: String? {
-        return match.key
-    }
-
-    var automaticRefreshInterval: DateComponents? {
-        return DateComponents(day: 1)
-    }
-
-    var automaticRefreshEndDate: Date? {
-        // Automatically refresh the match info until a few days after the match has been played
-        // (Mostly looking for new videos)
-        guard let endDate = match.event.endDate else {
-            return nil
-        }
-        return Calendar.current.date(byAdding: DateComponents(day: 7), to: endDate)
-    }
-
+    var refreshKey: String? { matchKey }
+    var automaticRefreshInterval: DateComponents? { DateComponents(day: 1) }
+    // Phase 2: match.event.endDate not available without an extra fetch.
+    var automaticRefreshEndDate: Date? { nil }
     var isDataSourceEmpty: Bool {
-        // TODO: Think about doing a quiet refresh in the background for match videos on initial load...
-        // https://github.com/the-blue-alliance/the-blue-alliance-ios/issues/135
-        return match.videos.count == 0 || match.event.name == nil
+        // Match hasn't loaded yet, or it has loaded but has no videos.
+        (match?.videos.count ?? 0) == 0
     }
 
     @objc func refresh() {
-        var eventOperation: TBAKitOperation?
-        if match.event.name == nil {
-            eventOperation = tbaKit.fetchEvent(key: match.event.key, completion: { [self] (result, notModified) in
-                guard case .success(let object) = result, let event = object, !notModified else {
-                    return
+        Task { @MainActor in
+            do {
+                if let fetched = try await api.match(key: matchKey) {
+                    apply(match: fetched)
                 }
-
-                let context = persistentContainer.newBackgroundContext()
-                context.performChangesAndWait({
-                    Event.insert(event, in: context)
-                }, saved: { [unowned self] in
-                    self.markTBARefreshSuccessful(tbaKit, operation: eventOperation!)
-                }, errorRecorder: errorRecorder)
-            })
+            } catch {
+                errorRecorder.record(error)
+            }
         }
-
-        var matchOperation: TBAKitOperation!
-        matchOperation = tbaKit.fetchMatch(key: match.key, { [self] (result, notModified) in
-            let context = persistentContainer.newBackgroundContext()
-            context.performChangesAndWait({
-                switch result {
-                case .success(let match):
-                    if let match = match {
-                        Match.insert(match, in: context)
-                    } else if !notModified {
-                        // TODO: Delete match, bump back up navigation stack
-                    }
-                default:
-                    break
-                }
-
-            }, saved: { [unowned self] in
-                self.markTBARefreshSuccessful(tbaKit, operation: matchOperation)
-            }, errorRecorder: errorRecorder)
-        })
-        addRefreshOperations([eventOperation, matchOperation].compactMap({ $0 }))
     }
 
+}
+
+// Bridges the API's `Match.VideosPayloadPayload` to the existing `Playable`
+// contract that `PlayerView` consumes. Only YouTube videos are playable —
+// the old `MatchVideo.youtubeKey` mapped the same way.
+private struct MatchVideoPlayable: Playable {
+    let video: Components.Schemas.Match.VideosPayloadPayload
+
+    var youtubeKey: String? {
+        video._type == "youtube" ? video.key : nil
+    }
 }

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchViewController.swift
@@ -2,18 +2,20 @@ import CoreData
 import Firebase
 import MyTBAKit
 import Photos
+import TBAAPI
 import TBAData
 import TBAKit
 import UIKit
 
 class MatchViewController: MyTBAContainerViewController {
 
-    private(set) var match: Match
-    private lazy var contextObserver: CoreDataContextObserver<Event> = {
-        return CoreDataContextObserver(context: persistentContainer.viewContext)
-    }()
+    private let matchKey: String
+    private let teamKey: String?
+
+    private var match: Components.Schemas.Match?
 
     private(set) var infoViewController: MatchInfoViewController
+    private let breakdownViewController: MatchBreakdownViewController
 
     private let pasteboard: UIPasteboard?
     private let photoLibrary: PHPhotoLibrary?
@@ -21,36 +23,29 @@ class MatchViewController: MyTBAContainerViewController {
     private let urlOpener: URLOpener
 
     override var subscribableModel: MyTBASubscribable {
-        return match
+        MatchSubscribable(modelKey: matchKey)
     }
 
     // MARK: Init
 
-    init(match: Match, team: Team? = nil, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, myTBA: MyTBA, dependencies: Dependencies) {
-        self.match = match
+    init(matchKey: String, teamKey: String? = nil, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, myTBA: MyTBA, dependencies: Dependencies) {
+        self.matchKey = matchKey
+        self.teamKey = teamKey
         self.pasteboard = pasteboard
         self.photoLibrary = photoLibrary
         self.statusService = statusService
         self.urlOpener = urlOpener
-        infoViewController = MatchInfoViewController(match: match, team: team, dependencies: dependencies)
 
-        // Only show match breakdown if year is 2015 or onward
-        var titles: [String]  = ["Info"]
-        let breakdownViewController: ContainableViewController? = {
-            if match.event.year < 2015 {
-                return nil
-            }
-            return MatchBreakdownViewController(match: match, dependencies: dependencies)
-        }()
-        if let _ = breakdownViewController {
-            titles.append("Breakdown")
-        }
+        infoViewController = MatchInfoViewController(matchKey: matchKey, teamKey: teamKey, dependencies: dependencies)
+        breakdownViewController = MatchBreakdownViewController(matchKey: matchKey,
+                                                               year: MatchKey.year(from: matchKey) ?? 0,
+                                                               dependencies: dependencies)
 
         super.init(
-            viewControllers: [infoViewController, breakdownViewController].compactMap({ $0 }),
-            navigationTitle: "\(match.friendlyName)",
-            navigationSubtitle: "@ \(match.event.friendlyNameWithYear)",
-            segmentedControlTitles: titles,
+            viewControllers: [infoViewController, breakdownViewController],
+            navigationTitle: "Match",
+            navigationSubtitle: nil,
+            segmentedControlTitles: ["Info", "Breakdown"],
             myTBA: myTBA,
             dependencies: dependencies
         )
@@ -67,28 +62,57 @@ class MatchViewController: MyTBAContainerViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        contextObserver.observeObject(object: match.event, state: .updated) { [weak self] (event, _) in
-            guard let self = self else { return }
-            self.navigationSubtitle = "@ \(event.friendlyNameWithYear)"
-        }
+        loadMatchAndEvent()
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        errorRecorder.log("Match: %@", [match.key])
+        errorRecorder.log("Match: %@", [matchKey])
+    }
+
+    private func loadMatchAndEvent() {
+        Task { @MainActor in
+            async let matchTask = try? await dependencies.api.match(key: matchKey)
+            async let eventTask = try? await dependencies.api.event(key: MatchKey.eventKey(from: matchKey))
+            let (match, event) = await (matchTask, eventTask)
+
+            if let match = match ?? nil {
+                self.match = match
+                self.navigationTitle = match.friendlyName
+                self.infoViewController.apply(match: match)
+                self.breakdownViewController.apply(match: match)
+            }
+            if let event = event ?? nil {
+                self.navigationSubtitle = "@ \(event.friendlyNameWithYear)"
+            }
+        }
     }
 
 }
 
-extension MatchViewController: MatchSummaryViewDelegate {
-    
-    func teamPressed(teamNumber: Int) {
-        // get team key that matches the target teamNumber
-        guard let team = match.teams.first(where: { Int($0.teamNumber) == teamNumber }) else { return }
+private struct MatchSubscribable: MyTBASubscribable {
+    let modelKey: String
+    var modelType: MyTBAModelType { .match }
+    static var notificationTypes: [NotificationType] {
+        [.upcomingMatch, .matchScore, .matchVideo]
+    }
+}
 
-        let teamAtEventVC = TeamAtEventViewController(team: team, event: match.event, myTBA: myTBA, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
+extension MatchViewController: MatchSummaryViewDelegate {
+
+    func teamPressed(teamNumber: Int) {
+        let targetKey = "frc\(teamNumber)"
+        guard let match, match.allTeamKeys.contains(targetKey) else { return }
+        // Team / Event lookups are still managed — Phase 3 swaps this for an
+        // API-driven path.
+        let team = Team.insert(targetKey, in: persistentContainer.viewContext)
+        guard let event = Event.findOrFetch(in: persistentContainer.viewContext,
+                                            matching: Event.predicate(key: match.eventKey)) else {
+            return
+        }
+        let teamAtEventVC = TeamAtEventViewController(team: team, event: event, myTBA: myTBA, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
         navigationController?.pushViewController(teamAtEventVC, animated: true)
     }
-    
+
 }

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchesViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchesViewController.swift
@@ -1,27 +1,27 @@
 import CoreData
 import Foundation
-import TBAData
-import TBAKit
 import MyTBAKit
+import TBAAPI
+import TBAData
 import UIKit
 
 protocol MatchesViewControllerDelegate: AnyObject {
     func showFilter()
-    func matchSelected(_ match: Match)
+    func matchSelected(matchKey: String)
 }
 
-class MatchesViewController: TBATableViewController {
+class MatchesViewController: TBATableViewController, Refreshable, Stateful {
 
     weak var delegate: MatchesViewControllerDelegate?
     var query: MatchQueryOptions = MatchQueryOptions.defaultQuery()
 
-    private let event: Event
-    private let team: Team?
+    private let eventKey: String
+    private let teamKey: String?
     private var myTBA: MyTBA
 
-    private var dataSource: TableViewDataSource<String, Match>!
-    private var fetchedResultsController: TableViewDataSourceFetchedResultsController<Match>!
+    private var dataSource: TableViewDataSource<String, Components.Schemas.Match>!
 
+    private var allMatches: [Components.Schemas.Match] = []
     private var favoriteTeamKeys: [String] = []
 
     lazy var matchQueryBarButtonItem: UIBarButtonItem = {
@@ -33,9 +33,9 @@ class MatchesViewController: TBATableViewController {
 
     // MARK: - Init
 
-    init(event: Event, team: Team? = nil, myTBA: MyTBA, dependencies: Dependencies) {
-        self.event = event
-        self.team = team
+    init(eventKey: String, teamKey: String? = nil, myTBA: MyTBA, dependencies: Dependencies) {
+        self.eventKey = eventKey
+        self.teamKey = teamKey
         self.myTBA = myTBA
 
         super.init(dependencies: dependencies)
@@ -51,9 +51,8 @@ class MatchesViewController: TBATableViewController {
         super.viewDidLoad()
 
         tableView.registerReusableCell(MatchTableViewCell.self)
-
-        tableView.dataSource = dataSource
         setupDataSource()
+        tableView.dataSource = dataSource
 
         updateInterface()
     }
@@ -69,75 +68,60 @@ class MatchesViewController: TBATableViewController {
     // MARK: Table View Data Source
 
     private func setupDataSource() {
-        dataSource = TableViewDataSource<String, Match>(tableView: tableView) { [weak self] (tableView, indexPath, match) -> UITableViewCell? in
+        dataSource = TableViewDataSource<String, Components.Schemas.Match>(tableView: tableView) { [weak self] tableView, indexPath, match in
             let cell = tableView.dequeueReusableCell(indexPath: indexPath) as MatchTableViewCell
 
             var baseTeamKeys: Set<String> = Set()
-            if let team = self?.team {
-                baseTeamKeys.insert(team.key)
+            if let teamKey = self?.teamKey {
+                baseTeamKeys.insert(teamKey)
             }
             if let query = self?.query, query.filter.favorites, let favoriteTeamKeys = self?.favoriteTeamKeys {
                 baseTeamKeys.formUnion(favoriteTeamKeys)
             }
-            cell.viewModel = MatchViewModel(match: match, baseTeamKeys: Array(baseTeamKeys))
-
+            cell.viewModel = MatchViewModel(apiMatch: match, baseTeamKeys: Array(baseTeamKeys))
             return cell
         }
         dataSource.statefulDelegate = self
-
-        let fetchRequest: NSFetchRequest<Match> = Match.fetchRequest()
-        setupFetchRequest(fetchRequest)
-
-        let frc = NSFetchedResultsController(fetchRequest: fetchRequest, managedObjectContext: persistentContainer.viewContext, sectionNameKeyPath: Match.compLevelSortOrderKeyPath(), cacheName: nil)
-        fetchedResultsController = TableViewDataSourceFetchedResultsController(dataSource: dataSource, fetchedResultsController: frc)
-
-        // Keep this LOC down here - or else we'll end up crashing with the fetchedResultsController init
         dataSource.delegate = self
     }
 
-    private func updateDataSource() {
-        fetchedResultsController.reconfigureFetchRequest(setupFetchRequest(_:))
-    }
+    private func applyMatches(_ matches: [Components.Schemas.Match]) {
+        let filtered = matches.filter(for: teamKey, favoriteTeamKeys: query.filter.favorites ? favoriteTeamKeys : nil)
+        let sorted = filtered.sorted(ascending: !query.sort.reverse)
 
-    private func setupFetchRequest(_ request: NSFetchRequest<Match>) {
-        let ascending = !query.sort.reverse
-        request.sortDescriptors = Match.sortDescriptors(ascending: ascending)
-
-        let matchPredicate: NSPredicate = {
-            if let team = team {
-                return Match.eventTeamPredicate(eventKey: event.key, teamKey: team.key)
-            } else {
-                return Match.eventPredicate(eventKey: event.key)
+        var snapshot = NSDiffableDataSourceSnapshot<String, Components.Schemas.Match>()
+        // Group by comp-level string so sections mirror the old FRC behavior.
+        var sectionOrder: [String] = []
+        var grouped: [String: [Components.Schemas.Match]] = [:]
+        for match in sorted {
+            let key = match.compLevelString
+            if grouped[key] == nil {
+                sectionOrder.append(key)
+                grouped[key] = []
             }
-        }()
-
-        // Filter for only Matches with myTBA Favorites
-        let myTBAFavoritesPredicate: NSPredicate? = {
-            guard query.filter.favorites else {
-                return nil
-            }
-            return Match.teamKeysPredicate(teamKeys: favoriteTeamKeys)
-        }()
-
-        request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [matchPredicate, myTBAFavoritesPredicate].compactMap({ $0 }))
+            grouped[key]?.append(match)
+        }
+        for section in sectionOrder {
+            snapshot.appendSections([section])
+            snapshot.appendItems(grouped[section] ?? [], toSection: section)
+        }
+        dataSource.apply(snapshot, animatingDifferences: false)
     }
 
     // MARK: TableViewDataSourceDelegate
 
     override func title(forSection section: Int) -> String? {
-        guard let firstMatch = fetchedResultsController.dataSource.itemIdentifier(for: IndexPath(row: 0, section: section)) else {
+        guard let firstMatch = dataSource.itemIdentifier(for: IndexPath(row: 0, section: section)) else {
             return "Matches"
         }
-        return "\(firstMatch.compLevel?.level ?? firstMatch.compLevelString) Matches"
+        return "\(firstMatch.compLevel.level) Matches"
     }
 
     // MARK: UITableView Delegate
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        guard let match = fetchedResultsController.dataSource.itemIdentifier(for: indexPath) else {
-            return
-        }
-        delegate?.matchSelected(match)
+        guard let match = dataSource.itemIdentifier(for: indexPath) else { return }
+        delegate?.matchSelected(matchKey: match.key)
     }
 
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
@@ -148,11 +132,12 @@ class MatchesViewController: TBATableViewController {
 
     func updateWithQuery(query: MatchQueryOptions) {
         self.query = query
-        // Save favoriteTeamKeys when query changes - since this can be expensive
+        // Favorite team keys are still on Core Data through Phase 5 — Phase 5
+        // swaps this for a read against `FavoritesStore`.
         favoriteTeamKeys = Favorite.favoriteTeamKeys(in: persistentContainer.viewContext)
 
         updateInterface()
-        updateDataSource()
+        applyMatches(allMatches)
     }
 
     // MARK: - Interface Methods
@@ -161,54 +146,30 @@ class MatchesViewController: TBATableViewController {
         delegate?.showFilter()
     }
 
-}
-
-extension MatchesViewController: Refreshable {
-
     // MARK: - Refreshable
 
-    var refreshKey: String? {
-        return "\(event.key)_matches"
-    }
-
-    var automaticRefreshInterval: DateComponents? {
-        return DateComponents(hour: 1)
-    }
-
-    var automaticRefreshEndDate: Date? {
-        // Automatically refresh event matches until the event is over
-        return event.endDate?.endOfDay()
-    }
-
+    var refreshKey: String? { "\(eventKey)_matches" }
+    var automaticRefreshInterval: DateComponents? { DateComponents(hour: 1) }
+    // Phase 2: event endDate not available without a separate fetch; deferred.
+    var automaticRefreshEndDate: Date? { nil }
     var isDataSourceEmpty: Bool {
-        // If we've changed our `filter` query option, an empty list is a valid state
-        if !query.filter.isDefault {
-            return false
-        }
-        return fetchedResultsController.isDataSourceEmpty
+        if !query.filter.isDefault { return false }
+        return allMatches.isEmpty
     }
 
     @objc func refresh() {
-        var operation: TBAKitOperation!
-        operation = tbaKit.fetchEventMatches(key: event.key) { [self] (result, notModified) in
-            guard case .success(let matches) = result, !notModified else {
-                return
+        Task { @MainActor in
+            do {
+                let fetched = try await dependencies.api.eventMatches(key: eventKey)
+                allMatches = fetched
+                applyMatches(fetched)
+            } catch {
+                errorRecorder.record(error)
             }
-
-            let context = persistentContainer.newBackgroundContext()
-            context.performChangesAndWait({
-                let event = context.object(with: self.event.objectID) as! Event
-                event.insert(matches)
-            }, saved: { [unowned self] in
-                markTBARefreshSuccessful(self.tbaKit, operation: operation)
-            }, errorRecorder: errorRecorder)
         }
-        addRefreshOperations([operation])
     }
 
-}
-
-extension MatchesViewController: Stateful {
+    // MARK: - Stateful
 
     var noDataText: String? {
         if query.isDefault {
@@ -217,7 +178,40 @@ extension MatchesViewController: Stateful {
             return "No matches matching filter options"
         }
     }
+}
 
+extension MatchesViewController {
+    // Placeholder so `MatchesViewControllerQueryable`'s `showFilter()` still compiles.
+}
+
+private extension Array where Element == Components.Schemas.Match {
+    func filter(for teamKey: String?, favoriteTeamKeys: [String]?) -> [Components.Schemas.Match] {
+        var results = self
+        if let teamKey {
+            results = results.filter { $0.allTeamKeys.contains(teamKey) }
+        }
+        if let favoriteTeamKeys, !favoriteTeamKeys.isEmpty {
+            let favSet = Set(favoriteTeamKeys)
+            results = results.filter { match in
+                match.allTeamKeys.contains(where: favSet.contains)
+            }
+        }
+        return results
+    }
+
+    func sorted(ascending: Bool) -> [Components.Schemas.Match] {
+        sorted { lhs, rhs in
+            if lhs.compLevelSortOrder != rhs.compLevelSortOrder {
+                return ascending
+                    ? lhs.compLevelSortOrder < rhs.compLevelSortOrder
+                    : lhs.compLevelSortOrder > rhs.compLevelSortOrder
+            }
+            if lhs.setNumber != rhs.setNumber {
+                return ascending ? lhs.setNumber < rhs.setNumber : lhs.setNumber > rhs.setNumber
+            }
+            return ascending ? lhs.matchNumber < rhs.matchNumber : lhs.matchNumber > rhs.matchNumber
+        }
+    }
 }
 
 protocol MatchesViewControllerQueryable: ContainerViewController, MatchQueryOptionsDelegate {

--- a/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBAViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBAViewController.swift
@@ -187,7 +187,7 @@ extension MyTBAViewController: MyTBATableViewControllerDelegate {
     }
 
     func matchSelected(_ match: Match) {
-        let viewController = MatchViewController(match: match, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
+        let viewController = MatchViewController(matchKey: match.key, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
         if let splitViewController = splitViewController {
             let navigationController = UINavigationController(rootViewController: viewController)
             splitViewController.showDetailViewController(navigationController, sender: nil)

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
@@ -34,7 +34,7 @@ class TeamAtEventViewController: ContainerViewController, ContainerTeamPushable 
         self.urlOpener = urlOpener
 
         let summaryViewController = TeamSummaryViewController(team: team, event: event, dependencies: dependencies)
-        matchesViewController = MatchesViewController(event: event, team: team, myTBA: myTBA, dependencies: dependencies)
+        matchesViewController = MatchesViewController(eventKey: event.key, teamKey: team.key, myTBA: myTBA, dependencies: dependencies)
         let mediaViewController = TeamMediaCollectionViewController(team: team, year: event.year, pasteboard: pasteboard, photoLibrary: photoLibrary, urlOpener: urlOpener, dependencies: dependencies)
         let statsViewController = TeamStatsViewController(team: team, event: event, dependencies: dependencies)
         let awardsViewController = EventAwardsViewController(eventKey: event.key, teamKey: team.key, dependencies: dependencies)
@@ -87,8 +87,18 @@ extension TeamAtEventViewController: MatchesViewControllerDelegate, MatchesViewC
         pushTeam(team: team)
     }
 
+    // TeamSummaryViewControllerDelegate (still on managed Match — Phase 3).
     func matchSelected(_ match: Match) {
-        let matchViewController = MatchViewController(match: match, team: team, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
+        pushMatch(matchKey: match.key)
+    }
+
+    // MatchesViewControllerDelegate (new API-based).
+    func matchSelected(matchKey: String) {
+        pushMatch(matchKey: matchKey)
+    }
+
+    private func pushMatch(matchKey: String) {
+        let matchViewController = MatchViewController(matchKey: matchKey, teamKey: team.key, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
         self.navigationController?.pushViewController(matchViewController, animated: true)
     }
 

--- a/the-blue-alliance-ios/ViewElements/Match/MatchViewModel.swift
+++ b/the-blue-alliance-ios/ViewElements/Match/MatchViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TBAAPI
 import TBAData
 
 struct MatchViewModel {
@@ -118,5 +119,59 @@ struct MatchViewModel {
             }
         }
         return rpCount
+    }
+
+    init(apiMatch match: Components.Schemas.Match, baseTeamKeys: [String] = []) {
+        matchName = match.friendlyName
+        hasVideos = match.videos.isEmpty
+
+        redAlliance = match.redAllianceTeamKeys
+        redScore = match.alliances.red.score < 0 ? nil : match.alliances.red.score
+
+        blueAlliance = match.blueAllianceTeamKeys
+        blueScore = match.alliances.blue.score < 0 ? nil : match.alliances.blue.score
+
+        dqs = match.dqTeamKeys
+        timeString = match.startTimeString ?? "No Time Yet"
+
+        // 2015 non-final matches have no winners or losers.
+        let matchYear = match.year ?? 0
+        let hasWinnersAndLosers = !(matchYear == 2015 && match.compLevel != .f)
+        redAllianceWon = hasWinnersAndLosers && match.winningAllianceString == "red"
+        blueAllianceWon = hasWinnersAndLosers && match.winningAllianceString == "blue"
+
+        self.baseTeamKeys = baseTeamKeys
+
+        let redBreakdown = match.breakdownDict?["red"] as? [String: Any]
+        let blueBreakdown = match.breakdownDict?["blue"] as? [String: Any]
+
+        var rpName1: String?
+        var rpName2: String?
+        switch matchYear {
+        case 2016:
+            rpName1 = "teleopDefensesBreached"
+            rpName2 = "teleopTowerCaptured"
+        case 2017:
+            rpName1 = "kPaRankingPointAchieved"
+            rpName2 = "rotorRankingPointAchieved"
+        case 2018:
+            rpName1 = "autoQuestRankingPoint"
+            rpName2 = "faceTheBossRankingPoint"
+        case 2019:
+            rpName1 = "completeRocketRankingPoint"
+            rpName2 = "habDockingRankingPoint"
+        case 2020, 2021:
+            rpName1 = "shieldEnergizedRankingPoint"
+            rpName2 = "shieldOperationalRankingPoint"
+        case 2022:
+            rpName1 = "cargoBonusRankingPoint"
+            rpName2 = "hangarBonusRankingPoint"
+        default:
+            break
+        }
+
+        let breakdownKeys: [String] = [rpName1, rpName2].compactMap { $0 }
+        redRPCount = MatchViewModel.calculateRP(breakdown: redBreakdown, breakdownKeys: breakdownKeys)
+        blueRPCount = MatchViewModel.calculateRP(breakdown: blueBreakdown, breakdownKeys: breakdownKeys)
     }
 }


### PR DESCRIPTION
All match VCs (list + detail + breakdown + info + query sheet) now read from TBAAPI directly. `Components.Schemas.Match` flows through the stack; the managed `Match` entity is only retained where un-migrated sub-VCs (TeamSummary/MyTBA — Phases 3/5) still produce one.

- `APIMatch+Helpers.swift`: ported conveniences on `Components.Schemas.Match` (`friendlyName`, `compLevelString`, `compLevelSortOrder`, red/blue/dq team keys, `startTime`/`startTimeString`, `breakdownDict` via Codable round-trip, `year`, `eventKeyFromMatchKey`) plus `level`/`levelShort`/`sortOrder` on the generated `CompLevelPayload` enum. `MatchKey.year(from:)` and `MatchKey.eventKey(from:)` pull year/event key from a match key string for callers that only have the key.
- `TBAAPI+Events.swift`: added `eventMatches(key:)` and `match(key:)`.
- `MatchesViewController`: takes `eventKey: String` and optional `teamKey: String?`. Fetches via `api.eventMatches`, holds `[Components.Schemas.Match]`, applies an in-memory filter+sort on query change. `MatchesViewControllerDelegate.matchSelected` now passes `matchKey: String`.
- `MatchViewController`: takes `matchKey: String`. Async-loads the match struct + its event (for nav title/subtitle) via two parallel TBAAPI calls, then hands the match down to Info/Breakdown sub-VCs. Uses a local `MatchSubscribable` struct for the `MyTBASubscribable` contract so we don't need to find-or-insert a managed Match.
- `MatchInfoViewController` / `MatchBreakdownViewController`: take `matchKey` (+ `year` for breakdown), fetch themselves on refresh, and expose `apply(match:)` so the parent can push the loaded struct. Video playback bridges the API video payload to the existing `Playable` protocol via a small wrapper.
- `MatchViewModel`: added API-shape init that produces the same cell view model from `Components.Schemas.Match` with the ported ranking-point calculation.

Call-site updates (managed callers pass `.key`):
- `EventViewController` → `MatchesViewController(eventKey:)` + new `matchSelected(matchKey:)` delegate impl + `MatchViewController(matchKey:)`.
- `TeamAtEventViewController` → `MatchesViewController(eventKey:teamKey:)`
  + both old (TeamSummary) and new (Matches) delegate impls push `MatchViewController(matchKey:)`.
- `MyTBAViewController` → `MatchViewController(matchKey: match.key)`.

`TBAViewController` gains a `var api: TBAAPI` accessor to match `TBATableViewController` / `ContainerViewController`. Test scaffolding updated to the new `matchKey:` init signature (the test scheme is still broken on `main` for unrelated reasons).

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots
