### PR TITLE
Phase 5: migrate myTBA onto FavoritesStore/SubscriptionsStore

### DIFF
--- a/the-blue-alliance-ios.xcodeproj/project.pbxproj
+++ b/the-blue-alliance-ios.xcodeproj/project.pbxproj
@@ -23,7 +23,6 @@
 		304ED0421EF1D2D300E31791 /* RankingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 304ED0401EF1D2D300E31791 /* RankingTableViewCell.swift */; };
 		371D9C9D2BA608EC00341829 /* MatchBreakdownConfigurator2024.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371D9C9C2BA608EC00341829 /* MatchBreakdownConfigurator2024.swift */; };
 		514C2EF52F8F0D5F00C674A9 /* MatchBreakdownConfigurator2026.swift in Sources */ = {isa = PBXBuildFile; fileRef = 514C2EF42F8F0D5E00C674A9 /* MatchBreakdownConfigurator2026.swift */; };
-		92009B5723DD49A60058E567 /* HandoffServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92009B5623DD49A60058E567 /* HandoffServiceTests.swift */; };
 		920240072AEB6AAD0003D118 /* PureLayout in Frameworks */ = {isa = PBXBuildFile; productRef = 920240062AEB6AAD0003D118 /* PureLayout */; };
 		920240092AEB6AC30003D118 /* TBAOperation in Frameworks */ = {isa = PBXBuildFile; productRef = 920240082AEB6AC30003D118 /* TBAOperation */; };
 		9202400B2AEB6ACF0003D118 /* Search in Frameworks */ = {isa = PBXBuildFile; productRef = 9202400A2AEB6ACF0003D118 /* Search */; };
@@ -303,7 +302,6 @@
 		304ED0401EF1D2D300E31791 /* RankingTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RankingTableViewCell.swift; sourceTree = "<group>"; };
 		371D9C9C2BA608EC00341829 /* MatchBreakdownConfigurator2024.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchBreakdownConfigurator2024.swift; sourceTree = "<group>"; };
 		514C2EF42F8F0D5E00C674A9 /* MatchBreakdownConfigurator2026.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MatchBreakdownConfigurator2026.swift; sourceTree = "<group>"; };
-		92009B5623DD49A60058E567 /* HandoffServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandoffServiceTests.swift; sourceTree = "<group>"; };
 		921D0B52222AF36A0056578A /* UIImage+TBATests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+TBATests.swift"; sourceTree = "<group>"; };
 		921D0B54222AF94C0056578A /* UIBarButtonItem+TBA.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIBarButtonItem+TBA.swift"; sourceTree = "<group>"; };
 		921D0B5A222AFFE40056578A /* UIBarButtonItem+TBATests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIBarButtonItem+TBATests.swift"; sourceTree = "<group>"; };
@@ -698,7 +696,6 @@
 				924459C720CB797E0007570D /* RetryService_Tests.swift */,
 				92564C6F216456800047917F /* Secrets_Tests.swift */,
 				9275956921B442AA00560D81 /* StatusServiceTests.swift */,
-				92009B5623DD49A60058E567 /* HandoffServiceTests.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1863,7 +1860,6 @@
 				92CC6D36234588810085867D /* Test.xcdatamodeld in Sources */,
 				92C8CE4621ACB05900683558 /* SubscribableTests.swift in Sources */,
 				921D0B5B222AFFE40056578A /* UIBarButtonItem+TBATests.swift in Sources */,
-				92009B5723DD49A60058E567 /* HandoffServiceTests.swift in Sources */,
 				9280EAED21685F310016621D /* RefreshableTests.swift in Sources */,
 				92564C70216456800047917F /* Secrets_Tests.swift in Sources */,
 				929820CF216968020080C1C8 /* TBATestCase.swift in Sources */,

--- a/the-blue-alliance-ios/AppDelegate/AppDelegate.swift
+++ b/the-blue-alliance-ios/AppDelegate/AppDelegate.swift
@@ -36,6 +36,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     lazy private var rootViewControllerPhone: PhoneRootViewController = {
         return PhoneRootViewController(fcmTokenProvider: messaging,
                                        myTBA: myTBA,
+                                       myTBAStores: myTBAStores,
                                        pasteboard: pasteboard,
                                        photoLibrary: photoLibrary,
                                        pushService: pushService,
@@ -47,6 +48,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     lazy private var rootViewControllerPad: PadRootViewController = {
         return PadRootViewController(fcmTokenProvider: messaging,
                                        myTBA: myTBA,
+                                       myTBAStores: myTBAStores,
                                        pasteboard: pasteboard,
                                        photoLibrary: photoLibrary,
                                        pushService: pushService,
@@ -62,11 +64,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                                                  tbaKit: tbaKit,
                                                  api: api,
                                                  userDefaults: userDefaults)
-    // Owned here and passed explicitly to myTBA view controllers when they're
-    // migrated off Core Data — not in Dependencies, since only a handful of
-    // screens need them.
+    // Owned here and wrapped in a MyTBAStores bag so the myTBA-related screens
+    // can thread both stores as one init param. Not in Dependencies — only a
+    // handful of screens care.
     let favoritesStore = FavoritesStore()
     let subscriptionsStore = SubscriptionsStore()
+    lazy var myTBAStores: MyTBAStores = MyTBAStores(favorites: favoritesStore, subscriptions: subscriptionsStore)
     private let errorRecorder = TBAErrorRecorder()
     lazy var indexDelegate: TBACoreDataCoreSpotlightDelegate = {
         let description = persistentContainer.persistentStoreDescriptions.first!

--- a/the-blue-alliance-ios/Protocols/SearchContainer.swift
+++ b/the-blue-alliance-ios/Protocols/SearchContainer.swift
@@ -46,6 +46,7 @@ extension SearchContainer where Self: SearchViewControllerDelegate {
 
 protocol SearchContainerDelegate {
     var myTBA: MyTBA { get }
+    var myTBAStores: MyTBAStores { get }
     var pasteboard: UIPasteboard? { get }
     var photoLibrary: PHPhotoLibrary? { get }
     var statusService: StatusService { get }
@@ -56,7 +57,7 @@ extension SearchContainerDelegate where Self: ContainerViewController {
 
     func eventSelected(_ event: Event) {
         // Show detail wrapped in a UINavigationController for our split view controller
-        let eventViewController = EventViewController(eventKey: event.key, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
+        let eventViewController = EventViewController(eventKey: event.key, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, myTBAStores: myTBAStores, dependencies: dependencies)
         if let splitViewController = splitViewController {
             let navigationController = UINavigationController(rootViewController: eventViewController)
             splitViewController.showDetailViewController(navigationController, sender: nil)
@@ -67,7 +68,7 @@ extension SearchContainerDelegate where Self: ContainerViewController {
 
     func teamSelected(_ team: Team) {
         // Show detail wrapped in a UINavigationController for our split view controller
-        let teamViewController = TeamViewController(teamKey: team.key, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
+        let teamViewController = TeamViewController(teamKey: team.key, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, myTBAStores: myTBAStores, dependencies: dependencies)
         if let splitViewController = splitViewController {
             let navigationController = UINavigationController(rootViewController: teamViewController)
             splitViewController.showDetailViewController(navigationController, sender: nil)

--- a/the-blue-alliance-ios/Protocols/Subscribable.swift
+++ b/the-blue-alliance-ios/Protocols/Subscribable.swift
@@ -3,24 +3,21 @@ import MyTBAKit
 import TBAUtils
 import UIKit
 
-// Subscribable is a protocol view controllers can conform to if they want to have
-// the UI to allow users to subscribe to notifications for models
-// Ex: The 'Event' view controller conforms to Subscribable, which shows the subscribe UI
-
 protocol Subscribable {
     var errorRecorder: ErrorRecorder { get }
     var myTBA: MyTBA { get }
     var favoriteBarButtonItem: UIBarButtonItem { get }
     var subscribableModel: MyTBASubscribable { get }
+    var myTBAStores: MyTBAStores { get }
 }
 
-extension Subscribable where Self: UIViewController, Self: Persistable {
+extension Subscribable where Self: UIViewController {
 
     func presentMyTBAPreferences() {
         let myTBAPreferencesViewController = MyTBAPreferenceViewController(errorRecorder: errorRecorder,
                                                                            subscribableModel: subscribableModel,
                                                                            myTBA: myTBA,
-                                                                           persistentContainer: persistentContainer)
+                                                                           myTBAStores: myTBAStores)
         let navigationController = UINavigationController(rootViewController: myTBAPreferencesViewController)
         navigationController.modalPresentationStyle = .formSheet
         navigationController.presentationController?.delegate = myTBAPreferencesViewController

--- a/the-blue-alliance-ios/Services/MyTBALocalStore.swift
+++ b/the-blue-alliance-ios/Services/MyTBALocalStore.swift
@@ -19,6 +19,18 @@ enum MyTBALocalStore {
     }
 }
 
+extension Notification.Name {
+    static let favoritesStoreDidChange = Notification.Name("favoritesStoreDidChange")
+    static let subscriptionsStoreDidChange = Notification.Name("subscriptionsStoreDidChange")
+}
+
+// Passed explicitly to the handful of view controllers that care about myTBA
+// state. Kept out of `Dependencies` since only myTBA-adjacent screens use it.
+struct MyTBAStores {
+    let favorites: FavoritesStore
+    let subscriptions: SubscriptionsStore
+}
+
 @Observable
 final class FavoritesStore {
 
@@ -34,15 +46,38 @@ final class FavoritesStore {
 
     func replaceAll(with favorites: [MyTBAFavorite]) {
         self.favorites = favorites
-        try? FileManager.default.createDirectory(at: fileURL.deletingLastPathComponent(),
-                                                 withIntermediateDirectories: true)
-        guard let data = try? JSONEncoder().encode(favorites) else { return }
-        try? data.write(to: fileURL, options: .atomic)
+        persist()
+    }
+
+    func upsert(_ favorite: MyTBAFavorite) {
+        var copy = favorites.filter { !($0.modelKey == favorite.modelKey && $0.modelType == favorite.modelType) }
+        copy.append(favorite)
+        favorites = copy
+        persist()
+    }
+
+    func remove(modelKey: String, modelType: MyTBAModelType) {
+        favorites = favorites.filter { !($0.modelKey == modelKey && $0.modelType == modelType) }
+        persist()
     }
 
     func clear() {
         favorites = []
         try? FileManager.default.removeItem(at: fileURL)
+        NotificationCenter.default.post(name: .favoritesStoreDidChange, object: self)
+    }
+
+    func favoriteTeamKeys() -> [String] {
+        favorites.filter { $0.modelType == .team }.map { $0.modelKey }
+    }
+
+    private func persist() {
+        try? FileManager.default.createDirectory(at: fileURL.deletingLastPathComponent(),
+                                                 withIntermediateDirectories: true)
+        if let data = try? JSONEncoder().encode(favorites) {
+            try? data.write(to: fileURL, options: .atomic)
+        }
+        NotificationCenter.default.post(name: .favoritesStoreDidChange, object: self)
     }
 }
 
@@ -61,14 +96,37 @@ final class SubscriptionsStore {
 
     func replaceAll(with subscriptions: [MyTBASubscription]) {
         self.subscriptions = subscriptions
-        try? FileManager.default.createDirectory(at: fileURL.deletingLastPathComponent(),
-                                                 withIntermediateDirectories: true)
-        guard let data = try? JSONEncoder().encode(subscriptions) else { return }
-        try? data.write(to: fileURL, options: .atomic)
+        persist()
+    }
+
+    func upsert(_ subscription: MyTBASubscription) {
+        var copy = subscriptions.filter { !($0.modelKey == subscription.modelKey && $0.modelType == subscription.modelType) }
+        copy.append(subscription)
+        subscriptions = copy
+        persist()
+    }
+
+    func remove(modelKey: String, modelType: MyTBAModelType) {
+        subscriptions = subscriptions.filter { !($0.modelKey == modelKey && $0.modelType == modelType) }
+        persist()
     }
 
     func clear() {
         subscriptions = []
         try? FileManager.default.removeItem(at: fileURL)
+        NotificationCenter.default.post(name: .subscriptionsStoreDidChange, object: self)
+    }
+
+    func subscription(modelKey: String, modelType: MyTBAModelType) -> MyTBASubscription? {
+        subscriptions.first { $0.modelKey == modelKey && $0.modelType == modelType }
+    }
+
+    private func persist() {
+        try? FileManager.default.createDirectory(at: fileURL.deletingLastPathComponent(),
+                                                 withIntermediateDirectories: true)
+        if let data = try? JSONEncoder().encode(subscriptions) {
+            try? data.write(to: fileURL, options: .atomic)
+        }
+        NotificationCenter.default.post(name: .subscriptionsStoreDidChange, object: self)
     }
 }

--- a/the-blue-alliance-ios/ViewControllers/Base/Containers/MyTBAContainerViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Base/Containers/MyTBAContainerViewController.swift
@@ -1,12 +1,11 @@
-import CoreData
 import Foundation
 import MyTBAKit
-import TBAKit
 import UIKit
 
 class MyTBAContainerViewController: ContainerViewController, Subscribable {
 
     let myTBA: MyTBA
+    let myTBAStores: MyTBAStores
 
     lazy var favoriteBarButtonItem: UIBarButtonItem = {
         return UIBarButtonItem(image: UIImage.starIcon, style: .plain, target: self, action: #selector(myTBAPreferencesTapped))
@@ -18,8 +17,9 @@ class MyTBAContainerViewController: ContainerViewController, Subscribable {
 
     // MARK: - Init
 
-    init(viewControllers: [ContainableViewController], navigationTitle: String? = nil, navigationSubtitle: String?  = nil, segmentedControlTitles: [String]? = nil, myTBA: MyTBA, dependencies: Dependencies) {
+    init(viewControllers: [ContainableViewController], navigationTitle: String? = nil, navigationSubtitle: String?  = nil, segmentedControlTitles: [String]? = nil, myTBA: MyTBA, myTBAStores: MyTBAStores, dependencies: Dependencies) {
         self.myTBA = myTBA
+        self.myTBAStores = myTBAStores
 
         super.init(viewControllers: viewControllers, navigationTitle: navigationTitle, navigationSubtitle: navigationSubtitle, segmentedControlTitles: segmentedControlTitles, dependencies: dependencies)
 

--- a/the-blue-alliance-ios/ViewControllers/Base/Containers/ScrollableContainerViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Base/Containers/ScrollableContainerViewController.swift
@@ -1,7 +1,5 @@
-import CoreData
 import Foundation
 import MyTBAKit
-import TBAKit
 import UIKit
 
 class HeaderContainerViewController: MyTBAContainerViewController {

--- a/the-blue-alliance-ios/ViewControllers/Districts/District/DistrictViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/District/DistrictViewController.swift
@@ -8,6 +8,7 @@ class DistrictViewController: ContainerViewController {
     private(set) var district: Components.Schemas.District
     private let year: Int
     private let myTBA: MyTBA
+    private let myTBAStores: MyTBAStores
     private let pasteboard: UIPasteboard?
     private let photoLibrary: PHPhotoLibrary?
     private let statusService: StatusService
@@ -19,12 +20,13 @@ class DistrictViewController: ContainerViewController {
 
     // MARK: - Init
 
-    init(district: Components.Schemas.District, year: Int? = nil, myTBA: MyTBA, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
+    init(district: Components.Schemas.District, year: Int? = nil, myTBA: MyTBA, myTBAStores: MyTBAStores, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
         self.district = district
         // District keys look like `2023fim` — year is the first 4 chars.
         let parsedYear = year ?? Int(district.key.prefix(4)) ?? statusService.currentSeason
         self.year = parsedYear
         self.myTBA = myTBA
+        self.myTBAStores = myTBAStores
         self.pasteboard = pasteboard
         self.photoLibrary = photoLibrary
         self.statusService = statusService
@@ -68,7 +70,7 @@ class DistrictViewController: ContainerViewController {
 extension DistrictViewController: EventsListViewControllerDelegate {
 
     func eventSelected(_ event: Components.Schemas.Event) {
-        let eventViewController = EventViewController(eventKey: event.key, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
+        let eventViewController = EventViewController(eventKey: event.key, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, myTBAStores: myTBAStores, dependencies: dependencies)
         self.navigationController?.pushViewController(eventViewController, animated: true)
     }
 
@@ -81,7 +83,7 @@ extension DistrictViewController: EventsListViewControllerDelegate {
 extension DistrictViewController: TeamsListViewControllerDelegate {
 
     func teamSelected(teamKey: String) {
-        let teamViewController = TeamViewController(teamKey: teamKey, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
+        let teamViewController = TeamViewController(teamKey: teamKey, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, myTBAStores: myTBAStores, dependencies: dependencies)
         self.navigationController?.pushViewController(teamViewController, animated: true)
     }
 
@@ -90,7 +92,7 @@ extension DistrictViewController: TeamsListViewControllerDelegate {
 extension DistrictViewController: DistrictRankingsViewControllerDelegate {
 
     func districtRankingSelected(_ ranking: Components.Schemas.DistrictRanking) {
-        let teamAtDistrictViewController = TeamAtDistrictViewController(ranking: ranking, district: district, year: year, myTBA: myTBA, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
+        let teamAtDistrictViewController = TeamAtDistrictViewController(ranking: ranking, district: district, year: year, myTBA: myTBA, myTBAStores: myTBAStores, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
         self.navigationController?.pushViewController(teamAtDistrictViewController, animated: true)
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Districts/District/Team@District/TeamAtDistrictViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/District/Team@District/TeamAtDistrictViewController.swift
@@ -12,6 +12,7 @@ class TeamAtDistrictViewController: ContainerViewController {
     private var ranking: Components.Schemas.DistrictRanking
 
     let myTBA: MyTBA
+    let myTBAStores: MyTBAStores
     let pasteboard: UIPasteboard?
     let photoLibrary: PHPhotoLibrary?
     let statusService: StatusService
@@ -21,12 +22,13 @@ class TeamAtDistrictViewController: ContainerViewController {
 
     // MARK: Init
 
-    init(ranking: Components.Schemas.DistrictRanking, district: Components.Schemas.District, year: Int, myTBA: MyTBA, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
+    init(ranking: Components.Schemas.DistrictRanking, district: Components.Schemas.District, year: Int, myTBA: MyTBA, myTBAStores: MyTBAStores, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
         self.ranking = ranking
         self.teamKey = ranking.teamKey
         self.districtKey = district.key
         self.year = year
         self.myTBA = myTBA
+        self.myTBAStores = myTBAStores
         self.pasteboard = pasteboard
         self.photoLibrary = photoLibrary
         self.statusService = statusService
@@ -66,7 +68,7 @@ class TeamAtDistrictViewController: ContainerViewController {
     // MARK: - Private Methods
 
     @objc private func pushTeam() {
-        let vc = TeamViewController(teamKey: teamKey, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
+        let vc = TeamViewController(teamKey: teamKey, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, myTBAStores: myTBAStores, dependencies: dependencies)
         navigationController?.pushViewController(vc, animated: true)
     }
 
@@ -76,7 +78,7 @@ extension TeamAtDistrictViewController: DistrictTeamSummaryViewControllerDelegat
 
     func eventPointsSelected(eventKey: String) {
         let year = Int(eventKey.prefix(4)) ?? self.year
-        let teamAtEventViewController = TeamAtEventViewController(teamKey: teamKey, eventKey: eventKey, year: year, myTBA: myTBA, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
+        let teamAtEventViewController = TeamAtEventViewController(teamKey: teamKey, eventKey: eventKey, year: year, myTBA: myTBA, myTBAStores: myTBAStores, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Districts/DistrictsContainerViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/DistrictsContainerViewController.swift
@@ -1,15 +1,12 @@
-import CoreData
-import Firebase
 import Foundation
 import MyTBAKit
 import TBAAPI
-import TBAData
-import TBAKit
 import UIKit
 
 class DistrictsContainerViewController: ContainerViewController {
 
     private let myTBA: MyTBA
+    private let myTBAStores: MyTBAStores
     private let statusService: StatusService
     private let urlOpener: URLOpener
 
@@ -23,8 +20,9 @@ class DistrictsContainerViewController: ContainerViewController {
 
     // MARK: - Init
 
-    init(myTBA: MyTBA, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
+    init(myTBA: MyTBA, myTBAStores: MyTBAStores, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
         self.myTBA = myTBA
+        self.myTBAStores = myTBAStores
         self.statusService = statusService
         self.urlOpener = urlOpener
 
@@ -93,7 +91,7 @@ extension DistrictsContainerViewController: DistrictsViewControllerDelegate {
 
     func districtSelected(_ district: Components.Schemas.District) {
         // Show detail wrapped in a UINavigationController for our split view controller
-        let districtViewController = DistrictViewController(district: district, myTBA: myTBA, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
+        let districtViewController = DistrictViewController(district: district, myTBA: myTBA, myTBAStores: myTBAStores, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
         if let splitViewController = splitViewController {
             let navigationController = UINavigationController(rootViewController: districtViewController)
             splitViewController.showDetailViewController(navigationController, sender: nil)

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventAlliancesViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventAlliancesViewController.swift
@@ -12,6 +12,7 @@ class EventAlliancesContainerViewController: ContainerViewController {
 
     private(set) var event: Components.Schemas.Event
     private let myTBA: MyTBA
+    private let myTBAStores: MyTBAStores
     private let pasteboard: UIPasteboard?
     private let photoLibrary: PHPhotoLibrary?
     private let statusService: StatusService
@@ -21,9 +22,10 @@ class EventAlliancesContainerViewController: ContainerViewController {
 
     // MARK: - Init
 
-    init(event: Components.Schemas.Event, myTBA: MyTBA, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
+    init(event: Components.Schemas.Event, myTBA: MyTBA, myTBAStores: MyTBAStores, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
         self.event = event
         self.myTBA = myTBA
+        self.myTBAStores = myTBAStores
         self.pasteboard = pasteboard
         self.photoLibrary = photoLibrary
         self.statusService = statusService
@@ -56,7 +58,7 @@ class EventAlliancesContainerViewController: ContainerViewController {
 extension EventAlliancesContainerViewController: EventAlliancesViewControllerDelegate {
 
     func teamSelected(_ team: Team) {
-        let teamAtEventViewController = TeamAtEventViewController(teamKey: team.key, eventKey: event.key, year: event.year, myTBA: myTBA, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
+        let teamAtEventViewController = TeamAtEventViewController(teamKey: team.key, eventKey: event.key, year: event.year, myTBA: myTBA, myTBAStores: myTBAStores, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventAwardsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventAwardsViewController.swift
@@ -11,6 +11,7 @@ class EventAwardsContainerViewController: ContainerViewController {
 
     private(set) var event: Components.Schemas.Event
     private let myTBA: MyTBA
+    private let myTBAStores: MyTBAStores
     private let pasteboard: UIPasteboard?
     private let photoLibrary: PHPhotoLibrary?
     private let statusService: StatusService
@@ -18,9 +19,10 @@ class EventAwardsContainerViewController: ContainerViewController {
 
     // MARK: - Init
 
-    init(event: Components.Schemas.Event, teamKey: String? = nil, myTBA: MyTBA, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
+    init(event: Components.Schemas.Event, teamKey: String? = nil, myTBA: MyTBA, myTBAStores: MyTBAStores, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
         self.event = event
         self.myTBA = myTBA
+        self.myTBAStores = myTBAStores
         self.pasteboard = pasteboard
         self.photoLibrary = photoLibrary
         self.statusService = statusService
@@ -53,7 +55,7 @@ class EventAwardsContainerViewController: ContainerViewController {
 extension EventAwardsContainerViewController: EventAwardsViewControllerDelegate {
 
     func teamSelected(_ team: Team) {
-        let teamAtEventViewController = TeamAtEventViewController(teamKey: team.key, eventKey: event.key, year: event.year, myTBA: myTBA, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
+        let teamAtEventViewController = TeamAtEventViewController(teamKey: team.key, eventKey: event.key, year: event.year, myTBA: myTBA, myTBAStores: myTBAStores, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventDistrictPointsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventDistrictPointsViewController.swift
@@ -11,6 +11,7 @@ class EventDistrictPointsContainerViewController: ContainerViewController {
 
     private(set) var event: Components.Schemas.Event
     private let myTBA: MyTBA
+    private let myTBAStores: MyTBAStores
     private let pasteboard: UIPasteboard?
     private let photoLibrary: PHPhotoLibrary?
     private let statusService: StatusService
@@ -18,9 +19,10 @@ class EventDistrictPointsContainerViewController: ContainerViewController {
 
     // MARK: - Init
 
-    init(event: Components.Schemas.Event, myTBA: MyTBA, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
+    init(event: Components.Schemas.Event, myTBA: MyTBA, myTBAStores: MyTBAStores, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
         self.event = event
         self.myTBA = myTBA
+        self.myTBAStores = myTBAStores
         self.pasteboard = pasteboard
         self.photoLibrary = photoLibrary
         self.statusService = statusService
@@ -53,7 +55,7 @@ class EventDistrictPointsContainerViewController: ContainerViewController {
 extension EventDistrictPointsContainerViewController: EventDistrictPointsViewControllerDelegate {
 
     func teamSelected(teamKey: String) {
-        let teamAtEventViewController = TeamAtEventViewController(teamKey: teamKey, eventKey: event.key, year: event.year, myTBA: myTBA, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
+        let teamAtEventViewController = TeamAtEventViewController(teamKey: teamKey, eventKey: event.key, year: event.year, myTBA: myTBA, myTBAStores: myTBAStores, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventViewController.swift
@@ -27,7 +27,7 @@ class EventViewController: MyTBAContainerViewController, EventStatusSubscribable
 
     // MARK: - Init
 
-    init(eventKey: String, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, myTBA: MyTBA, dependencies: Dependencies) {
+    init(eventKey: String, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, myTBA: MyTBA, myTBAStores: MyTBAStores, dependencies: Dependencies) {
         self.eventKey = eventKey
         self.pasteboard = pasteboard
         self.photoLibrary = photoLibrary
@@ -37,12 +37,13 @@ class EventViewController: MyTBAContainerViewController, EventStatusSubscribable
         infoViewController = EventInfoViewController(eventKey: eventKey, urlOpener: urlOpener, dependencies: dependencies)
         teamsViewController = EventTeamsViewController(eventKey: eventKey, dependencies: dependencies)
         rankingsViewController = EventRankingsViewController(eventKey: eventKey, dependencies: dependencies)
-        matchesViewController = MatchesViewController(eventKey: eventKey, myTBA: myTBA, dependencies: dependencies)
+        matchesViewController = MatchesViewController(eventKey: eventKey, myTBA: myTBA, favoritesStore: myTBAStores.favorites, dependencies: dependencies)
 
         super.init(viewControllers: [infoViewController, teamsViewController, rankingsViewController, matchesViewController],
                    navigationTitle: eventKey,
                    segmentedControlTitles: ["Info", "Teams", "Rankings", "Matches"],
                    myTBA: myTBA,
+                   myTBAStores: myTBAStores,
                    dependencies: dependencies)
 
         infoViewController.delegate = self
@@ -103,25 +104,25 @@ extension EventViewController: EventInfoViewControllerDelegate {
 
     func showAlliances() {
         guard let event else { return }
-        let eventAlliancesViewController = EventAlliancesContainerViewController(event: event, myTBA: myTBA, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
+        let eventAlliancesViewController = EventAlliancesContainerViewController(event: event, myTBA: myTBA, myTBAStores: myTBAStores, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
         self.navigationController?.pushViewController(eventAlliancesViewController, animated: true)
     }
 
     func showAwards() {
         guard let event else { return }
-        let eventAwardsViewController = EventAwardsContainerViewController(event: event, myTBA: myTBA, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
+        let eventAwardsViewController = EventAwardsContainerViewController(event: event, myTBA: myTBA, myTBAStores: myTBAStores, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
         self.navigationController?.pushViewController(eventAwardsViewController, animated: true)
     }
 
     func showDistrictPoints() {
         guard let event else { return }
-        let eventDistrictPointsViewController = EventDistrictPointsContainerViewController(event: event, myTBA: myTBA, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
+        let eventDistrictPointsViewController = EventDistrictPointsContainerViewController(event: event, myTBA: myTBA, myTBAStores: myTBAStores, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
         self.navigationController?.pushViewController(eventDistrictPointsViewController, animated: true)
     }
 
     func showInsights() {
         guard let event else { return }
-        let eventInsightsContainerViewController = EventInsightsContainerViewController(event: event, myTBA: myTBA, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
+        let eventInsightsContainerViewController = EventInsightsContainerViewController(event: event, myTBA: myTBA, myTBAStores: myTBAStores, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
         self.navigationController?.pushViewController(eventInsightsContainerViewController, animated: true)
     }
 
@@ -143,7 +144,7 @@ extension EventViewController: EventRankingsViewControllerDelegate {
 
     private func pushTeamAtEvent(teamKey: String) {
         let year = event?.year ?? Int(eventKey.prefix(4)) ?? 0
-        let teamAtEventViewController = TeamAtEventViewController(teamKey: teamKey, eventKey: eventKey, year: year, myTBA: myTBA, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
+        let teamAtEventViewController = TeamAtEventViewController(teamKey: teamKey, eventKey: eventKey, year: year, myTBA: myTBA, myTBAStores: myTBAStores, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)
     }
 
@@ -152,7 +153,7 @@ extension EventViewController: EventRankingsViewControllerDelegate {
 extension EventViewController: MatchesViewControllerDelegate, MatchesViewControllerQueryable {
 
     func matchSelected(matchKey: String) {
-        let matchViewController = MatchViewController(matchKey: matchKey, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
+        let matchViewController = MatchViewController(matchKey: matchKey, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, myTBAStores: myTBAStores, dependencies: dependencies)
         self.navigationController?.pushViewController(matchViewController, animated: true)
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/Stats/EventInsightsContainerViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/Stats/EventInsightsContainerViewController.swift
@@ -12,6 +12,7 @@ class EventInsightsContainerViewController: ContainerViewController {
 
     private(set) var event: Components.Schemas.Event
     private let myTBA: MyTBA
+    private let myTBAStores: MyTBAStores
     private let pasteboard: UIPasteboard?
     private let photoLibrary: PHPhotoLibrary?
     private let statusService: StatusService
@@ -21,9 +22,10 @@ class EventInsightsContainerViewController: ContainerViewController {
 
     // MARK: - Init
 
-    init(event: Components.Schemas.Event, myTBA: MyTBA, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
+    init(event: Components.Schemas.Event, myTBA: MyTBA, myTBAStores: MyTBAStores, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
         self.event = event
         self.myTBA = myTBA
+        self.myTBAStores = myTBAStores
         self.pasteboard = pasteboard
         self.photoLibrary = photoLibrary
         self.statusService = statusService
@@ -103,7 +105,7 @@ extension EventInsightsContainerViewController: EventTeamStatsSelectionDelegate 
     }
 
     func eventTeamStatSelected(teamKey: String) {
-        let teamAtEventViewController = TeamAtEventViewController(teamKey: teamKey, eventKey: event.key, year: event.year, myTBA: myTBA, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
+        let teamAtEventViewController = TeamAtEventViewController(teamKey: teamKey, eventKey: event.key, year: event.year, myTBA: myTBA, myTBAStores: myTBAStores, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Events/EventsContainerViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/EventsContainerViewController.swift
@@ -11,6 +11,7 @@ import UIKit
 class EventsContainerViewController: ContainerViewController {
 
     private(set) var myTBA: MyTBA
+    private(set) var myTBAStores: MyTBAStores
     private(set) var pasteboard: UIPasteboard?
     private(set) var photoLibrary: PHPhotoLibrary?
     private(set) var searchService: SearchService
@@ -24,8 +25,9 @@ class EventsContainerViewController: ContainerViewController {
 
     // MARK: - Init
 
-    init(myTBA: MyTBA, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, searchService: SearchService, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
+    init(myTBA: MyTBA, myTBAStores: MyTBAStores, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, searchService: SearchService, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
         self.myTBA = myTBA
+        self.myTBAStores = myTBAStores
         self.pasteboard = pasteboard
         self.photoLibrary = photoLibrary
         self.searchService = searchService
@@ -124,16 +126,13 @@ extension EventsContainerViewController: SearchContainer, SearchContainerDelegat
 extension EventsContainerViewController: EventsListViewControllerDelegate {
 
     func eventSelected(_ event: Components.Schemas.Event) {
-        // Push the legacy EventViewController using the event key. Phase 1b
-        // rewrites EventViewController to fetch from TBAAPI; until then the
-        // detail stack still reads from Core Data, which the WeekEvents
-        // refresh keeps warm via tbaKit.fetchEvents.
         let eventViewController = EventViewController(eventKey: event.key,
                                                       pasteboard: pasteboard,
                                                       photoLibrary: photoLibrary,
                                                       statusService: statusService,
                                                       urlOpener: urlOpener,
                                                       myTBA: myTBA,
+                                                      myTBAStores: myTBAStores,
                                                       dependencies: dependencies)
         if let splitViewController = splitViewController {
             let nav = UINavigationController(rootViewController: eventViewController)

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchViewController.swift
@@ -28,7 +28,7 @@ class MatchViewController: MyTBAContainerViewController {
 
     // MARK: Init
 
-    init(matchKey: String, teamKey: String? = nil, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, myTBA: MyTBA, dependencies: Dependencies) {
+    init(matchKey: String, teamKey: String? = nil, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, myTBA: MyTBA, myTBAStores: MyTBAStores, dependencies: Dependencies) {
         self.matchKey = matchKey
         self.teamKey = teamKey
         self.pasteboard = pasteboard
@@ -47,6 +47,7 @@ class MatchViewController: MyTBAContainerViewController {
             navigationSubtitle: nil,
             segmentedControlTitles: ["Info", "Breakdown"],
             myTBA: myTBA,
+            myTBAStores: myTBAStores,
             dependencies: dependencies
         )
 
@@ -105,7 +106,7 @@ extension MatchViewController: MatchSummaryViewDelegate {
         let targetKey = "frc\(teamNumber)"
         guard let match, match.allTeamKeys.contains(targetKey) else { return }
         let year = match.year ?? 0
-        let teamAtEventVC = TeamAtEventViewController(teamKey: targetKey, eventKey: match.eventKey, year: year, myTBA: myTBA, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
+        let teamAtEventVC = TeamAtEventViewController(teamKey: targetKey, eventKey: match.eventKey, year: year, myTBA: myTBA, myTBAStores: myTBAStores, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
         navigationController?.pushViewController(teamAtEventVC, animated: true)
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchesViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchesViewController.swift
@@ -1,8 +1,6 @@
-import CoreData
 import Foundation
 import MyTBAKit
 import TBAAPI
-import TBAData
 import UIKit
 
 protocol MatchesViewControllerDelegate: AnyObject {
@@ -18,6 +16,7 @@ class MatchesViewController: TBATableViewController, Refreshable, Stateful {
     private let eventKey: String
     private let teamKey: String?
     private var myTBA: MyTBA
+    private let favoritesStore: FavoritesStore
 
     private var dataSource: TableViewDataSource<String, Components.Schemas.Match>!
 
@@ -33,10 +32,11 @@ class MatchesViewController: TBATableViewController, Refreshable, Stateful {
 
     // MARK: - Init
 
-    init(eventKey: String, teamKey: String? = nil, myTBA: MyTBA, dependencies: Dependencies) {
+    init(eventKey: String, teamKey: String? = nil, myTBA: MyTBA, favoritesStore: FavoritesStore, dependencies: Dependencies) {
         self.eventKey = eventKey
         self.teamKey = teamKey
         self.myTBA = myTBA
+        self.favoritesStore = favoritesStore
 
         super.init(dependencies: dependencies)
     }
@@ -132,9 +132,7 @@ class MatchesViewController: TBATableViewController, Refreshable, Stateful {
 
     func updateWithQuery(query: MatchQueryOptions) {
         self.query = query
-        // Favorite team keys are still on Core Data through Phase 5 — Phase 5
-        // swaps this for a read against `FavoritesStore`.
-        favoriteTeamKeys = Favorite.favoriteTeamKeys(in: persistentContainer.viewContext)
+        favoriteTeamKeys = favoritesStore.favoriteTeamKeys()
 
         updateInterface()
         applyMatches(allMatches)

--- a/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBAPreferenceViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBAPreferenceViewController.swift
@@ -1,12 +1,7 @@
-import CoreData
 import MyTBAKit
-import TBAData
 import TBAUtils
 import UIKit
 
-// Two sections are a single no-title section for "Favorite" cell,
-// and a "Notification Settings" section with option cells
-// This view assume it's bein
 class MyTBAPreferenceViewController: UITableViewController, UIAdaptivePresentationControllerDelegate {
 
     var subscribableModel: MyTBASubscribable
@@ -16,7 +11,6 @@ class MyTBAPreferenceViewController: UITableViewController, UIAdaptivePresentati
         return subscribableModelClass.notificationTypes
     }()
 
-    var favorite: Favorite?
     let isFavoriteInitially: Bool
     var isFavorite: Bool {
         didSet {
@@ -24,7 +18,6 @@ class MyTBAPreferenceViewController: UITableViewController, UIAdaptivePresentati
         }
     }
 
-    var subscription: Subscription?
     let notificationsInitial: [NotificationType]
     var notifications: [NotificationType] {
         didSet {
@@ -34,7 +27,8 @@ class MyTBAPreferenceViewController: UITableViewController, UIAdaptivePresentati
 
     private let errorRecorder: ErrorRecorder
     let myTBA: MyTBA
-    let persistentContainer: NSPersistentContainer
+    private let favoritesStore: FavoritesStore
+    private let subscriptionsStore: SubscriptionsStore
 
     var preferencesOperation: MyTBAOperation?
     let operationQueue = OperationQueue()
@@ -61,18 +55,19 @@ class MyTBAPreferenceViewController: UITableViewController, UIAdaptivePresentati
                                                           action: #selector(save))
     internal var saveActivityIndicatorBarButtonItem = UIBarButtonItem.activityIndicatorBarButtonItem()
 
-    init(errorRecorder: ErrorRecorder, subscribableModel: MyTBASubscribable, myTBA: MyTBA, persistentContainer: NSPersistentContainer) {
+    init(errorRecorder: ErrorRecorder, subscribableModel: MyTBASubscribable, myTBA: MyTBA, myTBAStores: MyTBAStores) {
         self.errorRecorder = errorRecorder
         self.subscribableModel = subscribableModel
         self.myTBA = myTBA
-        self.persistentContainer = persistentContainer
+        self.favoritesStore = myTBAStores.favorites
+        self.subscriptionsStore = myTBAStores.subscriptions
 
-        favorite = Favorite.fetch(modelKey: subscribableModel.modelKey, modelType: subscribableModel.modelType, in: persistentContainer.viewContext)
-        isFavorite = (favorite != nil)
+        let existingFavorite = favoritesStore.favorites.first { $0.modelKey == subscribableModel.modelKey && $0.modelType == subscribableModel.modelType }
+        isFavorite = (existingFavorite != nil)
         isFavoriteInitially = isFavorite
 
-        subscription = Subscription.fetch(modelKey: subscribableModel.modelKey, modelType: subscribableModel.modelType, in: persistentContainer.viewContext)
-        notifications = subscription?.notifications ?? []
+        let existingSubscription = subscriptionsStore.subscription(modelKey: subscribableModel.modelKey, modelType: subscribableModel.modelType)
+        notifications = existingSubscription?.notifications ?? []
         notificationsInitial = notifications
 
         super.init(style: .grouped)
@@ -108,7 +103,7 @@ class MyTBAPreferenceViewController: UITableViewController, UIAdaptivePresentati
     func updateInterface() {
         saveBarButtonItem.isEnabled = hasChanges
         isModalInPresentation = hasChanges
-        
+
         if isSaving {
             navigationItem.rightBarButtonItem = saveActivityIndicatorBarButtonItem
         } else {
@@ -128,36 +123,26 @@ class MyTBAPreferenceViewController: UITableViewController, UIAdaptivePresentati
     @objc func save() {
         preferencesOperation = myTBA.updatePreferences(modelKey: subscribableModel.modelKey, modelType: subscribableModel.modelType, favorite: isFavorite, notifications: notifications) { [weak self] (favoriteResponse, subscriptionResponse, error) in
             guard let self = self else { return }
-            let context = self.persistentContainer.newBackgroundContext()
 
-            context.performChangesAndWait({
-                if let favoriteResponse = favoriteResponse, favoriteResponse.code < 500 {
-                    if !self.isFavorite, let favorite = self.favorite {
-                        // Delete
-                        context.delete(context.object(with: favorite.objectID))
-                    } else if self.isFavorite {
-                        // Insert
-                        Favorite.insert(modelKey: self.subscribableModel.modelKey, modelType: self.subscribableModel.modelType, in: context)
-                    }
+            if let favoriteResponse = favoriteResponse, favoriteResponse.code < 500 {
+                if self.isFavorite {
+                    self.favoritesStore.upsert(MyTBAFavorite(modelKey: self.subscribableModel.modelKey, modelType: self.subscribableModel.modelType))
+                } else {
+                    self.favoritesStore.remove(modelKey: self.subscribableModel.modelKey, modelType: self.subscribableModel.modelType)
                 }
+            }
 
-                if let subscriptionResponse = subscriptionResponse, subscriptionResponse.code < 500 {
-                    let hasNotifications = !self.notifications.isEmpty
-                    if !hasNotifications, let subscription = self.subscription {
-                        // Delete
-                        context.delete(context.object(with: subscription.objectID))
-                    } else if hasNotifications {
-                        if let subscription = self.subscription {
-                            // Update
-                            let sub = context.object(with: subscription.objectID) as! Subscription
-                            sub.notifications = self.notifications
-                        } else {
-                            // Insert
-                            Subscription.insert(modelKey: self.subscribableModel.modelKey, modelType: self.subscribableModel.modelType, notifications: self.notifications, in: context)
-                        }
-                    }
+            if let subscriptionResponse = subscriptionResponse, subscriptionResponse.code < 500 {
+                if self.notifications.isEmpty {
+                    self.subscriptionsStore.remove(modelKey: self.subscribableModel.modelKey, modelType: self.subscribableModel.modelType)
+                } else {
+                    self.subscriptionsStore.upsert(MyTBASubscription(modelKey: self.subscribableModel.modelKey, modelType: self.subscribableModel.modelType, notifications: self.notifications))
                 }
-            }, errorRecorder: self.errorRecorder)
+            }
+
+            if let error {
+                self.errorRecorder.record(error)
+            }
         }
 
         let dismissOperation = BlockOperation(block: { [weak self] in
@@ -165,12 +150,6 @@ class MyTBAPreferenceViewController: UITableViewController, UIAdaptivePresentati
 
             self.isSaving = false
             DispatchQueue.main.async {
-                if let favorite = self.favorite {
-                    self.persistentContainer.viewContext.refresh(favorite, mergeChanges: true)
-                }
-                if let subscription = self.subscription {
-                    self.persistentContainer.viewContext.refresh(subscription, mergeChanges: true)
-                }
                 self.dismiss(animated: true)
             }
         })

--- a/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
@@ -1,46 +1,71 @@
-import CoreData
 import Foundation
 import MyTBAKit
-import TBAData
-import TBAKit
+import TBAAPI
 import UIKit
 
-public enum MyTBASection {
+public enum MyTBASection: Int {
     case event
     case team
     case match
 
     static func section(for modelType: MyTBAModelType) -> MyTBASection? {
         switch modelType {
-        case .event:
-            return .event
-        case .team:
-            return .team
-        case .match:
-            return .match
-        default:
-            return nil
+        case .event: return .event
+        case .team: return .team
+        case .match: return .match
+        default: return nil
+        }
+    }
+
+    var headerTitle: String {
+        switch self {
+        case .event: return "Events"
+        case .team: return "Teams"
+        case .match: return "Matches"
         }
     }
 }
 
 protocol MyTBATableViewControllerDelegate: AnyObject {
-    func eventSelected(_ event: Event)
-    func teamSelected(_ team: Team)
-    func matchSelected(_ match: Match)
+    func eventSelected(eventKey: String)
+    func teamSelected(teamKey: String)
+    func matchSelected(matchKey: String)
 }
 
-/**
- MyTBATableViewController implements it's own NSFetchedResultsControllerDelegate, since we need to convert
- from a MyTBA model (Favorite, Subscription) in to a MyTBAEntity (Event, Team, Match)
- */
-class MyTBATableViewController<T: MyTBAEntity & MyTBAManaged, J: MyTBAModel>: TBATableViewController, NSFetchedResultsControllerDelegate {
+enum MyTBAItem: Hashable {
+    case event(key: String)
+    case team(key: String)
+    case match(key: String)
+
+    var section: MyTBASection {
+        switch self {
+        case .event: return .event
+        case .team: return .team
+        case .match: return .match
+        }
+    }
+
+    var modelKey: String {
+        switch self {
+        case .event(let key), .team(let key), .match(let key):
+            return key
+        }
+    }
+}
+
+// Abstract base. Two concrete subclasses below bind to FavoritesStore or
+// SubscriptionsStore, then pass their entries through the common rendering
+// pipeline (per-type caches populated lazily from TBAAPI).
+class MyTBATableViewController: TBATableViewController, NotificationObservable {
 
     let myTBA: MyTBA
     weak var delegate: MyTBATableViewControllerDelegate?
 
-    private var dataSource: TableViewDataSource<MyTBASection, NSManagedObject>!
-    private var fetchedResultsController: NSFetchedResultsController<T>!
+    private var dataSource: TableViewDataSource<MyTBASection, MyTBAItem>!
+
+    private var eventsCache: [String: Components.Schemas.Event] = [:]
+    private var teamsCache: [String: Components.Schemas.Team] = [:]
+    private var matchesCache: [String: Components.Schemas.Match] = [:]
 
     // MARK: Init
 
@@ -63,348 +88,329 @@ class MyTBATableViewController<T: MyTBAEntity & MyTBAManaged, J: MyTBAModel>: TB
         tableView.registerReusableCell(TeamTableViewCell.self)
         tableView.registerReusableCell(MatchTableViewCell.self)
 
-        tableView.dataSource = dataSource
         setupDataSource()
+        tableView.dataSource = dataSource
 
-        // Disable subscriptions
-        setupFetchedResultsController()
+        registerForStoreChanges()
+
+        rebuildSnapshot()
+    }
+
+    // MARK: Subclass Hooks
+
+    /// The entries to display, grouped by `MyTBASection` order.
+    var currentItems: [MyTBAItem] {
+        fatalError("Subclasses must override currentItems")
+    }
+
+    /// Kicks off a remote refresh, writes the result into the backing store.
+    func performRemoteRefresh() async throws {
+        fatalError("Subclasses must override performRemoteRefresh()")
+    }
+
+    /// Registers for the NotificationCenter name that the backing store posts on change.
+    func registerForStoreChanges() {
+        fatalError("Subclasses must override registerForStoreChanges()")
     }
 
     // MARK: Data Source
 
     private func setupDataSource() {
-        dataSource = TableViewDataSource<MyTBASection, NSManagedObject>(tableView: tableView, cellProvider: { (tableView, indexPath, obj) -> UITableViewCell? in
-            let fallbackCell = UITableViewCell()
-            fallbackCell.textLabel?.text = obj.description
-
-            // TODO: All Cell subclasses need gear icons
-            // https://github.com/the-blue-alliance/the-blue-alliance-ios/issues/179
-
-            if let event = obj as? Event {
-                return MyTBATableViewController.tableView(tableView, cellForEvent: event, at: indexPath)
-            } else if let team = obj as? Team {
-                return MyTBATableViewController.tableView(tableView, cellForTeam: team, at: indexPath)
-            } else if let match = obj as? Match {
-                return MyTBATableViewController.tableView(tableView, cellForMatch: match, at: indexPath)
-            } else {
-                return fallbackCell
+        dataSource = TableViewDataSource<MyTBASection, MyTBAItem>(tableView: tableView, cellProvider: { [weak self] tableView, indexPath, item in
+            guard let self = self else { return UITableViewCell() }
+            switch item {
+            case .event(let key):
+                let cell = tableView.dequeueReusableCell(indexPath: indexPath) as EventTableViewCell
+                if let event = self.eventsCache[key] {
+                    cell.viewModel = EventCellViewModel(name: event.safeShortName, location: event.locationString, dateString: event.dateString)
+                } else {
+                    cell.viewModel = EventCellViewModel(name: key, location: nil, dateString: nil)
+                }
+                return cell
+            case .team(let key):
+                let cell = tableView.dequeueReusableCell(indexPath: indexPath) as TeamTableViewCell
+                if let team = self.teamsCache[key] {
+                    cell.viewModel = TeamCellViewModel(teamNumber: "\(team.teamNumber)", nickname: team.displayNickname, location: team.locationString)
+                } else {
+                    cell.viewModel = TeamCellViewModel(teamNumber: TeamKey.trimFRCPrefix(key), nickname: "Team \(TeamKey.trimFRCPrefix(key))", location: nil)
+                }
+                return cell
+            case .match(let key):
+                let cell = tableView.dequeueReusableCell(indexPath: indexPath) as MatchTableViewCell
+                if let match = self.matchesCache[key] {
+                    cell.viewModel = MatchViewModel(apiMatch: match)
+                } else {
+                    cell.textLabel?.text = key
+                }
+                return cell
             }
         })
         dataSource.delegate = self
-        dataSource.statefulDelegate = self
     }
 
-    // MARK: NSFetchedResultsController
-
-    private func setupFetchedResultsController() {
-        let fetchRequest = NSFetchRequest<T>(entityName: T.entityName)
-
-        // Only show supported myTBA entities (basically, exclude team@event)
-        fetchRequest.predicate = T.supportedModelTypePredicate()
-        fetchRequest.sortDescriptors = T.sortDescriptors()
-
-        fetchedResultsController = NSFetchedResultsController(fetchRequest: fetchRequest,
-                                                              managedObjectContext: persistentContainer.viewContext,
-                                                              sectionNameKeyPath: T.modelTypeKeyPath(),
-                                                              cacheName: nil)
-        fetchedResultsController!.delegate = self
-        try! fetchedResultsController!.performFetch()
-    }
-
-    // MARK: NSFetchedResultsControllerDelegate
-
-    func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChangeContentWith snapshot: NSDiffableDataSourceSnapshotReference) {
-        var s = NSDiffableDataSourceSnapshot<MyTBASection, NSManagedObject>()
-        for section in snapshot.sectionIdentifiers.compactMap({ $0 as? String }) {
-            var items = snapshot.itemIdentifiersInSection(withIdentifier: section)
-                .compactMap { $0 as? NSManagedObjectID }
-                .compactMap { fetchedResultsController.managedObjectContext.object(with: $0) }
-                .compactMap { $0 as? T }
-                .compactMap { $0.tbaObject }
-            // Only add our section if we have items in the section
-            if items.isEmpty {
-                continue
-            }
-
-            guard let modelTypeRaw = Int(section) else {
-                continue
-            }
-            guard let modelType = MyTBAModelType(rawValue: modelTypeRaw) else {
-                continue
-            }
-            guard let sectionType = MyTBASection.section(for: modelType) else {
-                continue
-            }
-
-            // Sort our items before inserting
-            if let events = items as? [Event] {
-                items = events.sorted().sorted(by: { (lhs, rhs) -> Bool in
-                    // Second pass - sort by years in reverse order
-                    return lhs.year > rhs.year
-                })
-            } else if let teams = items as? [Team] {
-                items = teams.sorted()
-            } else if let matches = items as? [Match] {
-                items = matches.sorted()
-            }
-
-            s.appendSections([sectionType])
-            s.appendItems(items, toSection: sectionType)
+    private func rebuildSnapshot() {
+        var snapshot = NSDiffableDataSourceSnapshot<MyTBASection, MyTBAItem>()
+        let items = currentItems
+        let grouped = Dictionary(grouping: items, by: { $0.section })
+        for section in [MyTBASection.event, .team, .match] {
+            guard let sectionItems = grouped[section], !sectionItems.isEmpty else { continue }
+            let sorted = sortItems(sectionItems, in: section)
+            snapshot.appendSections([section])
+            snapshot.appendItems(sorted, toSection: section)
         }
-        dataSource.apply(s, animatingDifferences: false)
+        dataSource.apply(snapshot, animatingDifferences: false)
     }
 
-    // MARK: Table View Cells
-
-    private static func tableView(_ tableView: UITableView, cellForEvent event: Event, at indexPath: IndexPath) -> EventTableViewCell {
-        let cell = tableView.dequeueReusableCell(indexPath: indexPath) as EventTableViewCell
-        cell.viewModel = EventCellViewModel(name: event.safeNameYear, location: event.locationString, dateString: event.dateString)
-        return cell
-    }
-
-    private static func tableView(_ tableView: UITableView, cellForTeam team: Team, at indexPath: IndexPath) -> TeamTableViewCell {
-        let cell = tableView.dequeueReusableCell(indexPath: indexPath) as TeamTableViewCell
-        cell.viewModel = TeamCellViewModel(team: team)
-        return cell
-    }
-
-    private static func tableView(_ tableView: UITableView, cellForMatch match: Match, at indexPath: IndexPath) -> MatchTableViewCell {
-        let cell = tableView.dequeueReusableCell(indexPath: indexPath) as MatchTableViewCell
-        cell.viewModel = MatchViewModel(match: match)
-        return cell
+    private func sortItems(_ items: [MyTBAItem], in section: MyTBASection) -> [MyTBAItem] {
+        switch section {
+        case .event:
+            return items.sorted { lhs, rhs in
+                let lEvent = eventsCache[lhs.modelKey]
+                let rEvent = eventsCache[rhs.modelKey]
+                let lYear = lEvent.flatMap { Int($0.key.prefix(4)) } ?? 0
+                let rYear = rEvent.flatMap { Int($0.key.prefix(4)) } ?? 0
+                if lYear != rYear { return lYear > rYear }
+                if let l = lEvent, let r = rEvent { return l < r }
+                return lhs.modelKey < rhs.modelKey
+            }
+        case .team:
+            return items.sorted { lhs, rhs in
+                let l = teamsCache[lhs.modelKey].map { $0.teamNumber } ?? Int(TeamKey.trimFRCPrefix(lhs.modelKey)) ?? 0
+                let r = teamsCache[rhs.modelKey].map { $0.teamNumber } ?? Int(TeamKey.trimFRCPrefix(rhs.modelKey)) ?? 0
+                return l < r
+            }
+        case .match:
+            return items.sorted { lhs, rhs in
+                if let l = matchesCache[lhs.modelKey], let r = matchesCache[rhs.modelKey] {
+                    if l.compLevelSortOrder != r.compLevelSortOrder { return l.compLevelSortOrder < r.compLevelSortOrder }
+                    if l.setNumber != r.setNumber { return l.setNumber < r.setNumber }
+                    return l.matchNumber < r.matchNumber
+                }
+                return lhs.modelKey < rhs.modelKey
+            }
+        }
     }
 
     // MARK: TableViewDataSourceDelegate
 
     override func title(forSection sectionIndex: Int) -> String? {
-        let indexPath = IndexPath(item: 0, section: sectionIndex)
-        guard let item = dataSource.itemIdentifier(for: indexPath) else {
-            return nil
-        }
-        if item is Event {
-            return "Events"
-        } else if item is Team {
-            return "Teams"
-        } else if item is Match {
-            return "Matches"
-        } else {
-            return nil
-        }
+        let sections = dataSource.snapshot().sectionIdentifiers
+        guard sectionIndex < sections.count else { return nil }
+        return sections[sectionIndex].headerTitle
     }
 
     // MARK: UITableView Delegate
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        guard let obj = dataSource.itemIdentifier(for: indexPath) else {
-            return
-        }
-        if let event = obj as? Event {
-            delegate?.eventSelected(event)
-        } else if let team = obj as? Team {
-            delegate?.teamSelected(team)
-        } else if let match = obj as? Match {
-            delegate?.matchSelected(match)
-        } else {
-            tableView.deselectRow(at: indexPath, animated: true)
+        guard let item = dataSource.itemIdentifier(for: indexPath) else { return }
+        switch item {
+        case .event(let key): delegate?.eventSelected(eventKey: key)
+        case .team(let key): delegate?.teamSelected(teamKey: key)
+        case .match(let key): delegate?.matchSelected(matchKey: key)
         }
     }
 
-    // MARK: - Fetch Methods
+    // MARK: Stateful wiring
+
+    /// Concrete subclasses call this from `viewDidLoad` (after `super`) to
+    /// hook the no-data view into the data source. Declared on the base but
+    /// walked via an Obj-C cast so the base doesn't have to conform.
+    func attachStatefulDelegate() {
+        dataSource.statefulDelegate = self as? (Refreshable & Stateful)
+    }
+
+    // MARK: Refresh
+
+    func storeDidChange() {
+        rebuildSnapshot()
+    }
+
+    func refreshFromRemote(onSuccess: @escaping () -> Void) {
+        Task { @MainActor in
+            do {
+                try await performRemoteRefresh()
+                await fetchMissingItems()
+                rebuildSnapshot()
+                onSuccess()
+            } catch {
+                errorRecorder.record(error)
+            }
+        }
+    }
+
+    private func fetchMissingItems() async {
+        let items = currentItems
+        await withTaskGroup(of: Void.self) { group in
+            for item in items {
+                switch item {
+                case .event(let key) where eventsCache[key] == nil:
+                    group.addTask { [weak self] in
+                        guard let self = self else { return }
+                        if let event = try? await self.dependencies.api.event(key: key) {
+                            await MainActor.run { self.eventsCache[key] = event }
+                        }
+                    }
+                case .team(let key) where teamsCache[key] == nil:
+                    group.addTask { [weak self] in
+                        guard let self = self else { return }
+                        if let team = try? await self.dependencies.api.team(key: key) ?? nil {
+                            await MainActor.run { self.teamsCache[key] = team }
+                        }
+                    }
+                case .match(let key) where matchesCache[key] == nil:
+                    group.addTask { [weak self] in
+                        guard let self = self else { return }
+                        if let match = try? await self.dependencies.api.match(key: key) ?? nil {
+                            await MainActor.run { self.matchesCache[key] = match }
+                        }
+                    }
+                default: break
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Favorites
+
+class MyTBAFavoritesViewController: MyTBATableViewController, Refreshable, Stateful {
+
+    private let favoritesStore: FavoritesStore
+
+    init(myTBA: MyTBA, favoritesStore: FavoritesStore, dependencies: Dependencies) {
+        self.favoritesStore = favoritesStore
+        super.init(myTBA: myTBA, dependencies: dependencies)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        attachStatefulDelegate()
+    }
+
+    override var currentItems: [MyTBAItem] {
+        favoritesStore.favorites.compactMap { Self.item(for: $0.modelType, key: $0.modelKey) }
+    }
+
+    override func registerForStoreChanges() {
+        observeNotification(name: .favoritesStoreDidChange) { [weak self] _ in
+            Task { @MainActor in self?.storeDidChange() }
+        }
+    }
+
+    override func performRemoteRefresh() async throws {
+        let favorites: [MyTBAFavorite] = try await withCheckedThrowingContinuation { continuation in
+            let operation = myTBA.fetchFavorites { models, error in
+                if let error { continuation.resume(throwing: error); return }
+                continuation.resume(returning: models ?? [])
+            }
+            refreshOperationQueue.addOperation(operation)
+        }
+        await MainActor.run { favoritesStore.replaceAll(with: favorites) }
+    }
 
     @objc func refresh() {
-        if !myTBA.isAuthenticated {
-            return
-        }
-
-        var finalOperation: Operation!
-
-        var operation: MyTBAOperation!
-        operation = J.fetch(myTBA)() { [unowned self] (models, error) in
-            let context = self.persistentContainer.newBackgroundContext()
-            context.performChangesAndWait({
-                if let models = models as? [T.RemoteType] {
-                    T.insert(models, in: context)
-                    // Kickoff fetch for myTBA objects that don't exist
-                    models.forEach({
-                        self.fetchMyTBAObject($0, finalOperation)
-                    })
-                } else if error == nil {
-                    // If we don't get any models and we don't have an error, we probably don't have any models upstream
-                    context.deleteAllObjectsForEntity(entity: T.entity())
-                }
-            }, saved: {
-                self.markRefreshSuccessful()
-            }, errorRecorder: errorRecorder)
-        }
-        finalOperation = addRefreshOperations([operation])
+        guard myTBA.isAuthenticated else { return }
+        refreshFromRemote { [weak self] in self?.markRefreshSuccessful() }
     }
 
-    private func fetchMyTBAObject(_ myTBAModel: MyTBAModel, _ dependentOperation: Operation) {
-        guard let tbaKitOperation: TBAKitOperation = {
-            switch myTBAModel.modelType {
-            case .event:
-                return self.fetchEvent(myTBAModel)
-            case .team:
-                return self.fetchTeam(myTBAModel)
-            case .match:
-                return self.fetchMatch(myTBAModel)
-            default:
-                return nil
-            }
-        }() else { return }
-        dependentOperation.addDependency(tbaKitOperation)
-        refreshOperationQueue.addOperation(tbaKitOperation)
-    }
+    // MARK: - Refreshable
 
-    func fetchEvent(_ myTBAModel: MyTBAModel) -> TBAKitOperation {
-        var operation: TBAKitOperation!
-        operation = tbaKit.fetchEvent(key: myTBAModel.modelKey) { [self] (result, notModified) in
-            guard case .success(let object) = result, let event = object, !notModified else {
-                return
-            }
+    var refreshKey: String? { MyTBAFavorite.arrayKey }
+    var automaticRefreshInterval: DateComponents? { DateComponents(day: 1) }
+    var automaticRefreshEndDate: Date? { nil }
+    var isDataSourceEmpty: Bool { myTBA.isAuthenticated && favoritesStore.favorites.isEmpty }
 
-            let context = persistentContainer.newBackgroundContext()
-            context.performChangesAndWait({
-                Event.insert(event, in: context)
-            }, saved: { [unowned self] in
-                self.tbaKit.storeCacheHeaders(operation)
-                self.executeUpdate(myTBAModel)
-            }, errorRecorder: errorRecorder)
-        }
-        return operation
-    }
+    // MARK: - Stateful
 
-    func fetchTeam(_ myTBAModel: MyTBAModel) -> TBAKitOperation {
-        var operation: TBAKitOperation!
-        operation = tbaKit.fetchTeam(key: myTBAModel.modelKey) { [self] (result, notModified) in
-            guard case .success(let object) = result, let team = object, !notModified else {
-                return
-            }
+    var noDataText: String? { "No favorites" }
 
-            let context = persistentContainer.newBackgroundContext()
-            context.performChangesAndWait({
-                Team.insert(team, in: context)
-            }, saved: { [unowned self] in
-                self.tbaKit.storeCacheHeaders(operation)
-                self.executeUpdate(myTBAModel)
-            }, errorRecorder: errorRecorder)
-        }
-        return operation
-    }
-
-    func fetchMatch(_ myTBAModel: MyTBAModel) -> TBAKitOperation {
-        var operation: TBAKitOperation!
-        operation = tbaKit.fetchMatch(key: myTBAModel.modelKey) { [self] (result, notModified) in
-            guard case .success(let object) = result, let match = object, !notModified else {
-                return
-            }
-
-            let context = persistentContainer.newBackgroundContext()
-            context.performChangesAndWait({
-                Match.insert(match, in: context)
-            }, saved: { [unowned self] in
-                self.tbaKit.storeCacheHeaders(operation)
-                self.executeUpdate(myTBAModel)
-            }, errorRecorder: errorRecorder)
-        }
-        return operation
-    }
-
-    internal func executeUpdate(_ myTBAModel: MyTBAModel) {
-        let key = myTBAModel.modelKey
-        guard let op: Operation = { [self] in
-            switch myTBAModel.modelType {
-            case .event:
-                if let event = Event.findOrFetch(in: persistentContainer.viewContext, matching: Event.predicate(key: key)) {
-                    return updateObject(event, for: myTBAModel)
-                }
-                return nil
-            case .team:
-                if let team = Team.findOrFetch(in: persistentContainer.viewContext, matching: Team.predicate(key: key)) {
-                    return updateObject(team, for: myTBAModel)
-                }
-                return nil
-            case .match:
-                if let match = Match.findOrFetch(in: persistentContainer.viewContext, matching: Match.predicate(key: key)) {
-                    return updateObject(match, for: myTBAModel)
-                }
-                return nil
-            default:
-                return nil
-            }
-        }() else { return }
-
-        OperationQueue.main.addOperation(op)
-    }
-
-    private func updateObject(_ object: NSManagedObject, for model: MyTBAModel) -> Operation? {
-        guard let section = MyTBASection.section(for: model.modelType) else {
-            return nil
-        }
-        return BlockOperation {
-            var snapshot = self.dataSource.snapshot()
-
-            if !snapshot.sectionIdentifiers.contains(section) {
-                if snapshot.numberOfSections <= model.modelType.rawValue {
-                    snapshot.appendSections([section])
-                } else {
-                    let s = snapshot.sectionIdentifiers[model.modelType.rawValue]
-                    snapshot.insertSections([section], beforeSection: s)
-                }
-            }
-
-            if !snapshot.itemIdentifiers(inSection: section).contains(object) {
-                snapshot.appendItems([object], toSection: section)
-            }
-
-            var items = snapshot.itemIdentifiers(inSection: section)
-            // Sort our items before inserting
-            if let events = items as? [Event] {
-                items = events.sorted().sorted(by: { (lhs, rhs) -> Bool in
-                    // Second pass - sort by years in reverse order
-                    return lhs.year > rhs.year
-                })
-            } else if let teams = items as? [Team] {
-                items = teams.sorted()
-            } else if let matches = items as? [Match] {
-                items = matches.sorted()
-            }
-            snapshot.deleteItems(items)
-            snapshot.appendItems(items, toSection: section)
-
-            self.dataSource.apply(snapshot, animatingDifferences: true)
+    private static func item(for type: MyTBAModelType, key: String) -> MyTBAItem? {
+        switch type {
+        case .event: return .event(key: key)
+        case .team: return .team(key: key)
+        case .match: return .match(key: key)
+        default: return nil
         }
     }
-
 }
 
-extension MyTBATableViewController: Refreshable {
+// MARK: - Subscriptions
 
-    var refreshKey: String? {
-        return J.arrayKey
+class MyTBASubscriptionsViewController: MyTBATableViewController, Refreshable, Stateful {
+
+    private let subscriptionsStore: SubscriptionsStore
+
+    init(myTBA: MyTBA, subscriptionsStore: SubscriptionsStore, dependencies: Dependencies) {
+        self.subscriptionsStore = subscriptionsStore
+        super.init(myTBA: myTBA, dependencies: dependencies)
     }
 
-    var automaticRefreshInterval: DateComponents? {
-        return DateComponents(day: 1)
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 
-    var automaticRefreshEndDate: Date? {
-        return nil
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        attachStatefulDelegate()
     }
 
-    var isDataSourceEmpty: Bool {
-        if myTBA.isAuthenticated, dataSource.isDataSourceEmpty {
-            return true
+    override var currentItems: [MyTBAItem] {
+        subscriptionsStore.subscriptions.compactMap { Self.item(for: $0.modelType, key: $0.modelKey) }
+    }
+
+    override func registerForStoreChanges() {
+        observeNotification(name: .subscriptionsStoreDidChange) { [weak self] _ in
+            Task { @MainActor in self?.storeDidChange() }
         }
-        return false
     }
 
+    override func performRemoteRefresh() async throws {
+        let subs: [MyTBASubscription] = try await withCheckedThrowingContinuation { continuation in
+            let operation = myTBA.fetchSubscriptions { models, error in
+                if let error { continuation.resume(throwing: error); return }
+                continuation.resume(returning: models ?? [])
+            }
+            refreshOperationQueue.addOperation(operation)
+        }
+        await MainActor.run { subscriptionsStore.replaceAll(with: subs) }
+    }
+
+    @objc func refresh() {
+        guard myTBA.isAuthenticated else { return }
+        refreshFromRemote { [weak self] in self?.markRefreshSuccessful() }
+    }
+
+    // MARK: - Refreshable
+
+    var refreshKey: String? { MyTBASubscription.arrayKey }
+    var automaticRefreshInterval: DateComponents? { DateComponents(day: 1) }
+    var automaticRefreshEndDate: Date? { nil }
+    var isDataSourceEmpty: Bool { myTBA.isAuthenticated && subscriptionsStore.subscriptions.isEmpty }
+
+    // MARK: - Stateful
+
+    var noDataText: String? { "No subscriptions" }
+
+    private static func item(for type: MyTBAModelType, key: String) -> MyTBAItem? {
+        switch type {
+        case .event: return .event(key: key)
+        case .team: return .team(key: key)
+        case .match: return .match(key: key)
+        default: return nil
+        }
+    }
 }
 
-extension MyTBATableViewController: Stateful {
+// MARK: - NotificationObservable helper
 
-    var noDataText: String? {
-        return "No \(J.arrayKey)"
+protocol NotificationObservable: AnyObject {}
+
+extension NotificationObservable {
+    func observeNotification(name: Notification.Name, handler: @escaping (Notification) -> Void) {
+        NotificationCenter.default.addObserver(forName: name, object: nil, queue: .main, using: handler)
     }
-
 }

--- a/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBAViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBAViewController.swift
@@ -1,25 +1,23 @@
-import CoreData
 import FirebaseAuth
 import GoogleSignIn
 import MyTBAKit
 import Photos
 import PureLayout
-import TBAData
-import TBAKit
 import UIKit
 import UserNotifications
 
 class MyTBAViewController: ContainerViewController {
 
     private let myTBA: MyTBA
+    private let myTBAStores: MyTBAStores
     private let pasteboard: UIPasteboard?
     private let photoLibrary: PHPhotoLibrary?
     private let statusService: StatusService
     private let urlOpener: URLOpener
 
     private(set) var signInViewController: MyTBASignInViewController = MyTBASignInViewController()
-    private(set) var favoritesViewController: MyTBATableViewController<Favorite, MyTBAFavorite>
-    private(set) var subscriptionsViewController: MyTBATableViewController<Subscription, MyTBASubscription>
+    private(set) var favoritesViewController: MyTBAFavoritesViewController
+    private(set) var subscriptionsViewController: MyTBASubscriptionsViewController
 
     private var signInView: UIView! {
         return signInViewController.view
@@ -40,15 +38,16 @@ class MyTBAViewController: ContainerViewController {
         return myTBA.isAuthenticated
     }
 
-    init(myTBA: MyTBA, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
+    init(myTBA: MyTBA, myTBAStores: MyTBAStores, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
         self.myTBA = myTBA
+        self.myTBAStores = myTBAStores
         self.pasteboard = pasteboard
         self.photoLibrary = photoLibrary
         self.statusService = statusService
         self.urlOpener = urlOpener
 
-        favoritesViewController = MyTBATableViewController<Favorite, MyTBAFavorite>(myTBA: myTBA, dependencies: dependencies)
-        subscriptionsViewController = MyTBATableViewController<Subscription, MyTBASubscription>(myTBA: myTBA, dependencies: dependencies)
+        favoritesViewController = MyTBAFavoritesViewController(myTBA: myTBA, favoritesStore: myTBAStores.favorites, dependencies: dependencies)
+        subscriptionsViewController = MyTBASubscriptionsViewController(myTBA: myTBA, subscriptionsStore: myTBAStores.subscriptions, dependencies: dependencies)
 
         super.init(viewControllers: [favoritesViewController, subscriptionsViewController],
                    segmentedControlTitles: ["Favorites", "Subscriptions"],
@@ -71,10 +70,6 @@ class MyTBAViewController: ContainerViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // TODO: Fix the white status bar/white UINavigationController during sign in
-        // https://github.com/the-blue-alliance/the-blue-alliance-ios/issues/180
-        // modalPresentationCapturesStatusBarAppearance = true
 
         styleInterface()
 
@@ -118,7 +113,6 @@ class MyTBAViewController: ContainerViewController {
                 self?.errorRecorder.record(error)
                 self?.showErrorAlert(with: "Unable to sign out of myTBA - \(error.localizedDescription)")
             } else {
-                // Run on main thread, since we delete our Core Data objects on the main thread.
                 DispatchQueue.main.async {
                     self?.logoutSuccessful()
                 }
@@ -134,21 +128,16 @@ class MyTBAViewController: ContainerViewController {
         GIDSignIn.sharedInstance.signOut()
         try! Auth.auth().signOut()
 
-        // Cancel any ongoing requests
-        for vc in [favoritesViewController, subscriptionsViewController] as! [Refreshable] {
+        for vc in [favoritesViewController, subscriptionsViewController] as [Refreshable] {
             vc.cancelRefresh()
         }
 
-        // Remove all locally stored myTBA data
         removeMyTBAData()
     }
 
     func removeMyTBAData() {
-        persistentContainer.viewContext.deleteAllObjectsForEntity(entity: Favorite.entity())
-        persistentContainer.viewContext.deleteAllObjectsForEntity(entity: Subscription.entity())
-
-        // Clear notifications
-        persistentContainer.viewContext.performSaveOrRollback(errorRecorder: errorRecorder)
+        myTBAStores.favorites.clear()
+        myTBAStores.subscriptions.clear()
     }
 
     // MARK: - Interface Methods
@@ -166,28 +155,22 @@ class MyTBAViewController: ContainerViewController {
 
 extension MyTBAViewController: MyTBATableViewControllerDelegate {
 
-    func eventSelected(_ event: Event) {
-        let viewController = EventViewController(eventKey: event.key, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
-        if let splitViewController = splitViewController {
-            let navigationController = UINavigationController(rootViewController: viewController)
-            splitViewController.showDetailViewController(navigationController, sender: nil)
-        } else if let navigationController = navigationController {
-            navigationController.pushViewController(viewController, animated: true)
-        }
+    func eventSelected(eventKey: String) {
+        let viewController = EventViewController(eventKey: eventKey, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, myTBAStores: myTBAStores, dependencies: dependencies)
+        pushOrShowDetail(viewController)
     }
 
-    func teamSelected(_ team: Team) {
-        let viewController = TeamViewController(teamKey: team.key, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
-        if let splitViewController = splitViewController {
-            let navigationController = UINavigationController(rootViewController: viewController)
-            splitViewController.showDetailViewController(navigationController, sender: nil)
-        } else if let navigationController = navigationController {
-            navigationController.pushViewController(viewController, animated: true)
-        }
+    func teamSelected(teamKey: String) {
+        let viewController = TeamViewController(teamKey: teamKey, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, myTBAStores: myTBAStores, dependencies: dependencies)
+        pushOrShowDetail(viewController)
     }
 
-    func matchSelected(_ match: Match) {
-        let viewController = MatchViewController(matchKey: match.key, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
+    func matchSelected(matchKey: String) {
+        let viewController = MatchViewController(matchKey: matchKey, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, myTBAStores: myTBAStores, dependencies: dependencies)
+        pushOrShowDetail(viewController)
+    }
+
+    private func pushOrShowDetail(_ viewController: UIViewController) {
         if let splitViewController = splitViewController {
             let navigationController = UINavigationController(rootViewController: viewController)
             splitViewController.showDetailViewController(navigationController, sender: nil)

--- a/the-blue-alliance-ios/ViewControllers/Root/PadRootViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Root/PadRootViewController.swift
@@ -10,6 +10,7 @@ class PadRootViewController: UISplitViewController, RootController {
 
     let fcmTokenProvider: FCMTokenProvider
     let myTBA: MyTBA
+    let myTBAStores: MyTBAStores
     let pasteboard: UIPasteboard?
     let photoLibrary: PHPhotoLibrary?
     let pushService: PushService
@@ -21,6 +22,7 @@ class PadRootViewController: UISplitViewController, RootController {
     lazy fileprivate var masterViewController: PadMasterViewController = {
         return PadMasterViewController(fcmTokenProvider: fcmTokenProvider,
                                        myTBA: myTBA,
+                                       myTBAStores: myTBAStores,
                                        pasteboard: pasteboard,
                                        photoLibrary: photoLibrary,
                                        pushService: pushService,
@@ -41,9 +43,10 @@ class PadRootViewController: UISplitViewController, RootController {
         return navigationController
     }()
 
-    init(fcmTokenProvider: FCMTokenProvider, myTBA: MyTBA, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, pushService: PushService, searchService: SearchService, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
+    init(fcmTokenProvider: FCMTokenProvider, myTBA: MyTBA, myTBAStores: MyTBAStores, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, pushService: PushService, searchService: SearchService, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
         self.fcmTokenProvider = fcmTokenProvider
         self.myTBA = myTBA
+        self.myTBAStores = myTBAStores
         self.pasteboard = pasteboard
         self.photoLibrary = photoLibrary
         self.pushService = pushService
@@ -70,6 +73,7 @@ private class PadMasterViewController: ContainerViewController, RootController {
 
     let fcmTokenProvider: FCMTokenProvider
     let myTBA: MyTBA
+    let myTBAStores: MyTBAStores
     let pasteboard: UIPasteboard?
     let photoLibrary: PHPhotoLibrary?
     let pushService: PushService
@@ -79,9 +83,10 @@ private class PadMasterViewController: ContainerViewController, RootController {
 
     var searchController: UISearchController!
 
-    init(fcmTokenProvider: FCMTokenProvider, myTBA: MyTBA, pasteboard: UIPasteboard?, photoLibrary: PHPhotoLibrary?, pushService: PushService, searchService: SearchService, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
+    init(fcmTokenProvider: FCMTokenProvider, myTBA: MyTBA, myTBAStores: MyTBAStores, pasteboard: UIPasteboard?, photoLibrary: PHPhotoLibrary?, pushService: PushService, searchService: SearchService, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
         self.fcmTokenProvider = fcmTokenProvider
         self.myTBA = myTBA
+        self.myTBAStores = myTBAStores
         self.pasteboard = pasteboard
         self.photoLibrary = photoLibrary
         self.pushService = pushService

--- a/the-blue-alliance-ios/ViewControllers/Root/PhoneRootViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Root/PhoneRootViewController.swift
@@ -10,6 +10,7 @@ class PhoneRootViewController: UITabBarController, RootController {
 
     let fcmTokenProvider: FCMTokenProvider
     let myTBA: MyTBA
+    let myTBAStores: MyTBAStores
     let pasteboard: UIPasteboard?
     let photoLibrary: PHPhotoLibrary?
     let pushService: PushService
@@ -18,9 +19,10 @@ class PhoneRootViewController: UITabBarController, RootController {
     let urlOpener: URLOpener
     let dependencies: Dependencies
 
-    init(fcmTokenProvider: FCMTokenProvider, myTBA: MyTBA, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, pushService: PushService, searchService: SearchService, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
+    init(fcmTokenProvider: FCMTokenProvider, myTBA: MyTBA, myTBAStores: MyTBAStores, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, pushService: PushService, searchService: SearchService, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
         self.fcmTokenProvider = fcmTokenProvider
         self.myTBA = myTBA
+        self.myTBAStores = myTBAStores
         self.pasteboard = pasteboard
         self.photoLibrary = photoLibrary
         self.pushService = pushService

--- a/the-blue-alliance-ios/ViewControllers/Root/RootController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Root/RootController.swift
@@ -57,6 +57,7 @@ enum RootType: CaseIterable {
 protocol RootController {
     var fcmTokenProvider: FCMTokenProvider { get }
     var myTBA: MyTBA { get }
+    var myTBAStores: MyTBAStores { get }
     var pasteboard: UIPasteboard? { get }
     var photoLibrary: PHPhotoLibrary? { get }
     var pushService: PushService { get }
@@ -70,6 +71,7 @@ extension RootController {
 
     var eventsViewController: EventsContainerViewController {
         return EventsContainerViewController(myTBA: myTBA,
+                                             myTBAStores: myTBAStores,
                                              pasteboard: pasteboard,
                                              photoLibrary: photoLibrary,
                                              searchService: searchService,
@@ -80,6 +82,7 @@ extension RootController {
 
     var teamsViewController: TeamsContainerViewController {
         return TeamsContainerViewController(myTBA: myTBA,
+                                            myTBAStores: myTBAStores,
                                             pasteboard: pasteboard,
                                             photoLibrary: photoLibrary,
                                             searchService: searchService,
@@ -90,6 +93,7 @@ extension RootController {
 
     var districtsViewController: DistrictsContainerViewController {
         return DistrictsContainerViewController(myTBA: myTBA,
+                                                myTBAStores: myTBAStores,
                                                 statusService: statusService,
                                                 urlOpener: urlOpener,
                                                 dependencies: dependencies)
@@ -106,6 +110,7 @@ extension RootController {
 
     var myTBAViewController: MyTBAViewController {
         return MyTBAViewController(myTBA: myTBA,
+                                   myTBAStores: myTBAStores,
                                    pasteboard: pasteboard,
                                    photoLibrary: photoLibrary,
                                    statusService: statusService,

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamAtEventViewController.swift
@@ -14,6 +14,7 @@ class TeamAtEventViewController: ContainerViewController {
     let eventKey: String
 
     let myTBA: MyTBA
+    let myTBAStores: MyTBAStores
     let pasteboard: UIPasteboard?
     let photoLibrary: PHPhotoLibrary?
     let statusService: StatusService
@@ -27,17 +28,18 @@ class TeamAtEventViewController: ContainerViewController {
 
     // MARK: - Init
 
-    init(teamKey: String, eventKey: String, year: Int, myTBA: MyTBA, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
+    init(teamKey: String, eventKey: String, year: Int, myTBA: MyTBA, myTBAStores: MyTBAStores, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
         self.teamKey = teamKey
         self.eventKey = eventKey
         self.myTBA = myTBA
+        self.myTBAStores = myTBAStores
         self.pasteboard = pasteboard
         self.photoLibrary = photoLibrary
         self.statusService = statusService
         self.urlOpener = urlOpener
 
         summaryViewController = TeamSummaryViewController(teamKey: teamKey, eventKey: eventKey, dependencies: dependencies)
-        matchesViewController = MatchesViewController(eventKey: eventKey, teamKey: teamKey, myTBA: myTBA, dependencies: dependencies)
+        matchesViewController = MatchesViewController(eventKey: eventKey, teamKey: teamKey, myTBA: myTBA, favoritesStore: myTBAStores.favorites, dependencies: dependencies)
         // TeamMediaCollectionViewController is still on managed Team (Phase 3c).
         let managedTeam = Team.insert(teamKey, in: dependencies.persistentContainer.viewContext)
         mediaViewController = TeamMediaCollectionViewController(team: managedTeam, year: year, pasteboard: pasteboard, photoLibrary: photoLibrary, urlOpener: urlOpener, dependencies: dependencies)
@@ -92,22 +94,22 @@ class TeamAtEventViewController: ContainerViewController {
     // MARK: - Private Methods
 
     @objc private func pushEvent() {
-        let eventViewController = EventViewController(eventKey: eventKey, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
+        let eventViewController = EventViewController(eventKey: eventKey, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, myTBAStores: myTBAStores, dependencies: dependencies)
         navigationController?.pushViewController(eventViewController, animated: true)
     }
 
     private func pushTeamAtEvent(teamKey: String, eventKey: String, year: Int) {
-        let vc = TeamAtEventViewController(teamKey: teamKey, eventKey: eventKey, year: year, myTBA: myTBA, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
+        let vc = TeamAtEventViewController(teamKey: teamKey, eventKey: eventKey, year: year, myTBA: myTBA, myTBAStores: myTBAStores, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
         navigationController?.pushViewController(vc, animated: true)
     }
 
     private func pushTeam(teamKey: String) {
-        let vc = TeamViewController(teamKey: teamKey, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
+        let vc = TeamViewController(teamKey: teamKey, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, myTBAStores: myTBAStores, dependencies: dependencies)
         navigationController?.pushViewController(vc, animated: true)
     }
 
     private func pushMatch(matchKey: String) {
-        let matchViewController = MatchViewController(matchKey: matchKey, teamKey: teamKey, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, dependencies: dependencies)
+        let matchViewController = MatchViewController(matchKey: matchKey, teamKey: teamKey, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, myTBAStores: myTBAStores, dependencies: dependencies)
         navigationController?.pushViewController(matchViewController, animated: true)
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
@@ -45,7 +45,7 @@ class TeamViewController: HeaderContainerViewController {
 
     // MARK: Init
 
-    init(teamKey: String, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, myTBA: MyTBA, dependencies: Dependencies) {
+    init(teamKey: String, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, myTBA: MyTBA, myTBAStores: MyTBAStores, dependencies: Dependencies) {
         self.teamKey = teamKey
         self.pasteboard = pasteboard
         self.photoLibrary = photoLibrary
@@ -73,6 +73,7 @@ class TeamViewController: HeaderContainerViewController {
             navigationSubtitle: "----",
             segmentedControlTitles: ["Info", "Events", "Media"],
             myTBA: myTBA,
+            myTBAStores: myTBAStores,
             dependencies: dependencies
         )
 
@@ -190,7 +191,7 @@ extension TeamViewController: SelectTableViewControllerDelegate {
 extension TeamViewController: EventsListViewControllerDelegate {
 
     func eventSelected(_ event: Components.Schemas.Event) {
-        let teamAtEventViewController = TeamAtEventViewController(teamKey: teamKey, eventKey: event.key, year: event.year, myTBA: myTBA, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
+        let teamAtEventViewController = TeamAtEventViewController(teamKey: teamKey, eventKey: event.key, year: event.year, myTBA: myTBA, myTBAStores: myTBAStores, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)
     }
 }

--- a/the-blue-alliance-ios/ViewControllers/Teams/TeamsContainerViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/TeamsContainerViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 class TeamsContainerViewController: ContainerViewController {
 
     private(set) var myTBA: MyTBA
+    private(set) var myTBAStores: MyTBAStores
     private(set) var pasteboard: UIPasteboard?
     private(set) var photoLibrary: PHPhotoLibrary?
     private(set) var searchService: SearchService
@@ -21,8 +22,9 @@ class TeamsContainerViewController: ContainerViewController {
 
     // MARK: - Init
 
-    init(myTBA: MyTBA, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, searchService: SearchService, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
+    init(myTBA: MyTBA, myTBAStores: MyTBAStores, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, searchService: SearchService, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
         self.myTBA = myTBA
+        self.myTBAStores = myTBAStores
         self.pasteboard = pasteboard
         self.photoLibrary = photoLibrary
         self.searchService = searchService


### PR DESCRIPTION
Retires the NSFetchedResultsController<Favorite>/<Subscription> pipeline behind the myTBA tab and replaces it with a local Codable store (the FavoritesStore / SubscriptionsStore pair added in Phase 0).

- MyTBAViewController now constructs two concrete subclasses — MyTBAFavoritesViewController and MyTBASubscriptionsViewController — each owning its store and rendering a shared UITableViewDiffableDataSource keyed by `MyTBAItem` (enum of event/team/match + modelKey). The per-type Event/Team/Match cache is populated lazily from TBAAPI on refresh.
- MyTBAPreferenceViewController reads/writes the stores via upsert/remove helpers, triggered by the existing myTBA.updatePreferences API call.
- MatchesViewController filters by favorite team keys via FavoritesStore.favoriteTeamKeys() instead of a Core Data predicate.
- Introduces a MyTBAStores aggregator struct, owned on AppDelegate, and threads it through the container chain (Events/Teams/Districts roots, Event/Team/Match detail VCs, their sub-tabs) so the star-button path in MyTBAContainerViewController can reach both stores.
- Both stores post a NotificationCenter name on mutation so the open myTBA tab refreshes without explicit coupling.
- Logout clears both stores via .clear().

Drops TBAData/TBAKit imports from every touched VC; the generic MyTBATableViewController<T, J> is gone. Unit tests remain on their pre-Phase-0 wiring; Phase 7 rewrites them.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots
