### PR TITLE
Phase 8: add API type aliases, strip Components.Schemas noise

### DIFF
--- a/Packages/TBAAPI/Sources/TBAAPI/Extensions/TypeAliases.swift
+++ b/Packages/TBAAPI/Sources/TBAAPI/Extensions/TypeAliases.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+// Top-level aliases for the OpenAPI-generated models so downstream code can
+// say `Event` instead of `Components.Schemas.Event`. These are public so the
+// main app target picks them up through `import TBAAPI`.
+public typealias APIStatus = Components.Schemas.APIStatus
+public typealias Award = Components.Schemas.Award
+public typealias District = Components.Schemas.District
+public typealias DistrictRanking = Components.Schemas.DistrictRanking
+public typealias EliminationAlliance = Components.Schemas.EliminationAlliance
+public typealias Event = Components.Schemas.Event
+public typealias EventDistrictPoints = Components.Schemas.EventDistrictPoints
+public typealias EventInsights = Components.Schemas.EventInsights
+public typealias EventOPRs = Components.Schemas.EventOPRs
+public typealias EventRanking = Components.Schemas.EventRanking
+public typealias Match = Components.Schemas.Match
+public typealias Media = Components.Schemas.Media
+public typealias SearchIndex = Components.Schemas.SearchIndex
+public typealias Team = Components.Schemas.Team
+public typealias TeamEventStatus = Components.Schemas.TeamEventStatus
+public typealias Webcast = Components.Schemas.Webcast

--- a/the-blue-alliance-ios/Extensions/TBAAPI/APIEvent+Helpers.swift
+++ b/the-blue-alliance-ios/Extensions/TBAAPI/APIEvent+Helpers.swift
@@ -15,7 +15,7 @@ enum APIEventType: Int, CaseIterable {
     case unlabeled = -1
 }
 
-extension Components.Schemas.Event {
+extension Event {
 
     var eventTypeEnum: APIEventType? {
         APIEventType(rawValue: eventType)
@@ -140,7 +140,7 @@ extension Components.Schemas.Event {
     }
 }
 
-extension Components.Schemas.Event {
+extension Event {
 
     // Parsed Date form of the API's string date fields. The generated struct
     // stores `startDate` and `endDate` as ISO-ish `yyyy-MM-dd` strings; these

--- a/the-blue-alliance-ios/Extensions/TBAAPI/APIMatch+Helpers.swift
+++ b/the-blue-alliance-ios/Extensions/TBAAPI/APIMatch+Helpers.swift
@@ -1,7 +1,7 @@
 import Foundation
 import TBAAPI
 
-extension Components.Schemas.Match.CompLevelPayload {
+extension Match.CompLevelPayload {
 
     var sortOrder: Int {
         switch self {
@@ -34,7 +34,7 @@ extension Components.Schemas.Match.CompLevelPayload {
     }
 }
 
-extension Components.Schemas.Match {
+extension Match {
 
     var compLevelString: String { compLevel.rawValue }
 

--- a/the-blue-alliance-ios/Extensions/TBAAPI/APITeam+Helpers.swift
+++ b/the-blue-alliance-ios/Extensions/TBAAPI/APITeam+Helpers.swift
@@ -1,7 +1,7 @@
 import Foundation
 import TBAAPI
 
-extension Components.Schemas.Team {
+extension Team {
 
     // Matches the TBAData.Team.teamNumberNickname ("Team 254").
     var teamNumberNickname: String { "Team \(teamNumber)" }

--- a/the-blue-alliance-ios/Extensions/TBAAPI/APIWebcast+Helpers.swift
+++ b/the-blue-alliance-ios/Extensions/TBAAPI/APIWebcast+Helpers.swift
@@ -1,7 +1,7 @@
 import Foundation
 import TBAAPI
 
-extension Components.Schemas.Webcast {
+extension Webcast {
 
     // Matches the string enum in TBAData's `Webcast.type`.
     var typeString: String { _type.rawValue }

--- a/the-blue-alliance-ios/Extensions/TBAAPI/TBAAPI+Districts.swift
+++ b/the-blue-alliance-ios/Extensions/TBAAPI/TBAAPI+Districts.swift
@@ -3,7 +3,7 @@ import TBAAPI
 
 extension TBAAPI {
 
-    func districtsByYear(_ year: Int) async throws -> [Components.Schemas.District] {
+    func districtsByYear(_ year: Int) async throws -> [District] {
         let response = try await client.getDistrictsByYear(path: .init(year: year))
         switch response {
         case .ok(let ok):
@@ -19,7 +19,7 @@ extension TBAAPI {
         }
     }
 
-    func districtEvents(key districtKey: String) async throws -> [Components.Schemas.Event] {
+    func districtEvents(key districtKey: String) async throws -> [Event] {
         let response = try await client.getDistrictEvents(path: .init(districtKey: districtKey))
         switch response {
         case .ok(let ok):
@@ -35,7 +35,7 @@ extension TBAAPI {
         }
     }
 
-    func districtTeams(key districtKey: String) async throws -> [Components.Schemas.Team] {
+    func districtTeams(key districtKey: String) async throws -> [Team] {
         let response = try await client.getDistrictTeams(path: .init(districtKey: districtKey))
         switch response {
         case .ok(let ok):
@@ -51,7 +51,7 @@ extension TBAAPI {
         }
     }
 
-    func districtRankings(key districtKey: String) async throws -> [Components.Schemas.DistrictRanking] {
+    func districtRankings(key districtKey: String) async throws -> [DistrictRanking] {
         let response = try await client.getDistrictRankings(path: .init(districtKey: districtKey))
         switch response {
         case .ok(let ok):

--- a/the-blue-alliance-ios/Extensions/TBAAPI/TBAAPI+Events.swift
+++ b/the-blue-alliance-ios/Extensions/TBAAPI/TBAAPI+Events.swift
@@ -3,7 +3,7 @@ import TBAAPI
 
 extension TBAAPI {
 
-    func eventsByYear(_ year: Int) async throws -> [Components.Schemas.Event] {
+    func eventsByYear(_ year: Int) async throws -> [Event] {
         let response = try await client.getEventsByYear(path: .init(year: year))
         switch response {
         case .ok(let ok):
@@ -19,7 +19,7 @@ extension TBAAPI {
         }
     }
 
-    func event(key eventKey: String) async throws -> Components.Schemas.Event {
+    func event(key eventKey: String) async throws -> Event {
         let response = try await client.getEvent(path: .init(eventKey: eventKey))
         switch response {
         case .ok(let ok):
@@ -35,7 +35,7 @@ extension TBAAPI {
         }
     }
 
-    func eventTeams(key eventKey: String) async throws -> [Components.Schemas.Team] {
+    func eventTeams(key eventKey: String) async throws -> [Team] {
         let response = try await client.getEventTeams(path: .init(eventKey: eventKey))
         switch response {
         case .ok(let ok):
@@ -51,7 +51,7 @@ extension TBAAPI {
         }
     }
 
-    func eventRankings(key eventKey: String) async throws -> Components.Schemas.EventRanking? {
+    func eventRankings(key eventKey: String) async throws -> EventRanking? {
         let response = try await client.getEventRankings(path: .init(eventKey: eventKey))
         switch response {
         case .ok(let ok):
@@ -67,7 +67,7 @@ extension TBAAPI {
         }
     }
 
-    func eventAlliances(key eventKey: String) async throws -> [Components.Schemas.EliminationAlliance]? {
+    func eventAlliances(key eventKey: String) async throws -> [EliminationAlliance]? {
         let response = try await client.getEventAlliances(path: .init(eventKey: eventKey))
         switch response {
         case .ok(let ok):
@@ -83,7 +83,7 @@ extension TBAAPI {
         }
     }
 
-    func eventAwards(key eventKey: String) async throws -> [Components.Schemas.Award] {
+    func eventAwards(key eventKey: String) async throws -> [Award] {
         let response = try await client.getEventAwards(path: .init(eventKey: eventKey))
         switch response {
         case .ok(let ok):
@@ -99,7 +99,7 @@ extension TBAAPI {
         }
     }
 
-    func eventDistrictPoints(key eventKey: String) async throws -> Components.Schemas.EventDistrictPoints? {
+    func eventDistrictPoints(key eventKey: String) async throws -> EventDistrictPoints? {
         let response = try await client.getEventDistrictPoints(path: .init(eventKey: eventKey))
         switch response {
         case .ok(let ok):
@@ -115,7 +115,7 @@ extension TBAAPI {
         }
     }
 
-    func eventInsights(key eventKey: String) async throws -> Components.Schemas.EventInsights? {
+    func eventInsights(key eventKey: String) async throws -> EventInsights? {
         let response = try await client.getEventInsights(path: .init(eventKey: eventKey))
         switch response {
         case .ok(let ok):
@@ -131,7 +131,7 @@ extension TBAAPI {
         }
     }
 
-    func eventMatches(key eventKey: String) async throws -> [Components.Schemas.Match] {
+    func eventMatches(key eventKey: String) async throws -> [Match] {
         let response = try await client.getEventMatches(path: .init(eventKey: eventKey))
         switch response {
         case .ok(let ok):
@@ -147,7 +147,7 @@ extension TBAAPI {
         }
     }
 
-    func match(key matchKey: String) async throws -> Components.Schemas.Match? {
+    func match(key matchKey: String) async throws -> Match? {
         let response = try await client.getMatch(path: .init(matchKey: matchKey))
         switch response {
         case .ok(let ok):
@@ -163,7 +163,7 @@ extension TBAAPI {
         }
     }
 
-    func eventOPRs(key eventKey: String) async throws -> Components.Schemas.EventOPRs? {
+    func eventOPRs(key eventKey: String) async throws -> EventOPRs? {
         let response = try await client.getEventOPRs(path: .init(eventKey: eventKey))
         switch response {
         case .ok(let ok):

--- a/the-blue-alliance-ios/Extensions/TBAAPI/TBAAPI+Search.swift
+++ b/the-blue-alliance-ios/Extensions/TBAAPI/TBAAPI+Search.swift
@@ -3,7 +3,7 @@ import TBAAPI
 
 extension TBAAPI {
 
-    func getSearchIndex() async throws -> Components.Schemas.SearchIndex {
+    func getSearchIndex() async throws -> SearchIndex {
         let response = try await client.getSearchIndex()
         switch response {
         case .ok(let ok):

--- a/the-blue-alliance-ios/Extensions/TBAAPI/TBAAPI+Status.swift
+++ b/the-blue-alliance-ios/Extensions/TBAAPI/TBAAPI+Status.swift
@@ -3,7 +3,7 @@ import TBAAPI
 
 extension TBAAPI {
 
-    func getStatus() async throws -> Components.Schemas.APIStatus {
+    func getStatus() async throws -> APIStatus {
         let response = try await client.getStatus()
         switch response {
         case .ok(let ok):

--- a/the-blue-alliance-ios/Extensions/TBAAPI/TBAAPI+Teams.swift
+++ b/the-blue-alliance-ios/Extensions/TBAAPI/TBAAPI+Teams.swift
@@ -5,12 +5,12 @@ extension TBAAPI {
 
     // TBA's `/teams/{page}` paginates at 500 per page. We keep fetching until
     // a page comes back empty — that's the API's signal that we're past the end.
-    func allTeams() async throws -> [Components.Schemas.Team] {
-        var all: [Components.Schemas.Team] = []
+    func allTeams() async throws -> [Team] {
+        var all: [Team] = []
         var page = 0
         while true {
             let response = try await client.getTeams(path: .init(pageNum: page))
-            let batch: [Components.Schemas.Team]
+            let batch: [Team]
             switch response {
             case .ok(let ok):
                 batch = try ok.body.json
@@ -26,7 +26,7 @@ extension TBAAPI {
         return all
     }
 
-    func team(key teamKey: String) async throws -> Components.Schemas.Team? {
+    func team(key teamKey: String) async throws -> Team? {
         let response = try await client.getTeam(path: .init(teamKey: teamKey))
         switch response {
         case .ok(let ok):
@@ -58,7 +58,7 @@ extension TBAAPI {
         }
     }
 
-    func teamEventsByYear(key teamKey: String, year: Int) async throws -> [Components.Schemas.Event] {
+    func teamEventsByYear(key teamKey: String, year: Int) async throws -> [Event] {
         let response = try await client.getTeamEventsByYear(path: .init(teamKey: teamKey, year: year))
         switch response {
         case .ok(let ok):
@@ -74,7 +74,7 @@ extension TBAAPI {
         }
     }
 
-    func teamEventMatches(teamKey: String, eventKey: String) async throws -> [Components.Schemas.Match] {
+    func teamEventMatches(teamKey: String, eventKey: String) async throws -> [Match] {
         let response = try await client.getTeamEventMatches(path: .init(teamKey: teamKey, eventKey: eventKey))
         switch response {
         case .ok(let ok):
@@ -90,7 +90,7 @@ extension TBAAPI {
         }
     }
 
-    func teamEventAwards(teamKey: String, eventKey: String) async throws -> [Components.Schemas.Award] {
+    func teamEventAwards(teamKey: String, eventKey: String) async throws -> [Award] {
         let response = try await client.getTeamEventAwards(path: .init(teamKey: teamKey, eventKey: eventKey))
         switch response {
         case .ok(let ok):
@@ -106,7 +106,7 @@ extension TBAAPI {
         }
     }
 
-    func teamEventStatus(teamKey: String, eventKey: String) async throws -> Components.Schemas.TeamEventStatus? {
+    func teamEventStatus(teamKey: String, eventKey: String) async throws -> TeamEventStatus? {
         let response = try await client.getTeamEventStatus(path: .init(teamKey: teamKey, eventKey: eventKey))
         switch response {
         case .ok(let ok):
@@ -122,7 +122,7 @@ extension TBAAPI {
         }
     }
 
-    func teamMediaByYear(teamKey: String, year: Int) async throws -> [Components.Schemas.Media] {
+    func teamMediaByYear(teamKey: String, year: Int) async throws -> [Media] {
         let response = try await client.getTeamMediaByYear(path: .init(teamKey: teamKey, year: year))
         switch response {
         case .ok(let ok):

--- a/the-blue-alliance-ios/Extensions/TBAAPI/WeekEventsGrouping.swift
+++ b/the-blue-alliance-ios/Extensions/TBAAPI/WeekEventsGrouping.swift
@@ -5,7 +5,7 @@ enum WeekEventsGrouping {
 
     // Picks a single representative event per week / event-type / offseason-month
     // so the UI can render one row per bucket in the year/week selector.
-    static func weekEvents(for year: Int, from events: [Components.Schemas.Event]) -> [Components.Schemas.Event] {
+    static func weekEvents(for year: Int, from events: [Event]) -> [Event] {
         let candidates = events
             .filter { $0.year == year }
             // Exclude CMP divisions — we keep those out of the week picker.
@@ -26,7 +26,7 @@ enum WeekEventsGrouping {
         var handledOffseasonMonths: Set<String> = []
         var handledUnknown = false
 
-        var picked: [Components.Schemas.Event] = []
+        var picked: [Event] = []
         for event in candidates {
             guard let type = event.eventTypeEnum else {
                 // Unknown event type — keep one representative.
@@ -62,11 +62,11 @@ enum WeekEventsGrouping {
 
 // MARK: - Comparable port
 
-extension Components.Schemas.Event: Comparable {
+extension Event: Comparable {
 
     // Port of TBAData.Event's `Comparable` ordering:
     //   Preseason, Week 1, Week 2, …, Week 7, CMP divisions, CMP finals, FoC, Offseason, Unlabeled
-    public static func < (lhs: Components.Schemas.Event, rhs: Components.Schemas.Event) -> Bool {
+    public static func < (lhs: Event, rhs: Event) -> Bool {
         if lhs.year != rhs.year {
             return lhs.year < rhs.year
         }

--- a/the-blue-alliance-ios/Services/StatusService.swift
+++ b/the-blue-alliance-ios/Services/StatusService.swift
@@ -29,7 +29,7 @@ struct AppStatus {
         self.downEventKeys = downEventKeys
     }
 
-    init(apiStatus: Components.Schemas.APIStatus) {
+    init(apiStatus: APIStatus) {
         self.currentSeason = apiStatus.currentSeason
         self.maxSeason = apiStatus.maxSeason
         self.minAppVersion = apiStatus.ios.minAppVersion

--- a/the-blue-alliance-ios/ViewControllers/Districts/District/DistrictRankingsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/District/DistrictRankingsViewController.swift
@@ -3,7 +3,7 @@ import TBAAPI
 import UIKit
 
 protocol DistrictRankingsViewControllerDelegate: AnyObject {
-    func districtRankingSelected(_ ranking: Components.Schemas.DistrictRanking)
+    func districtRankingSelected(_ ranking: DistrictRanking)
 }
 
 class DistrictRankingsViewController: TBASearchableTableViewController, Refreshable, Stateful {
@@ -12,8 +12,8 @@ class DistrictRankingsViewController: TBASearchableTableViewController, Refresha
 
     private let districtKey: String
 
-    private var dataSource: TableViewDataSource<String, Components.Schemas.DistrictRanking>!
-    private var allRankings: [Components.Schemas.DistrictRanking] = []
+    private var dataSource: TableViewDataSource<String, DistrictRanking>!
+    private var allRankings: [DistrictRanking] = []
 
     // MARK: - Init
 
@@ -49,7 +49,7 @@ class DistrictRankingsViewController: TBASearchableTableViewController, Refresha
     // MARK: Table View Data Source
 
     private func setupDataSource() {
-        dataSource = TableViewDataSource<String, Components.Schemas.DistrictRanking>(tableView: tableView) { tableView, indexPath, ranking in
+        dataSource = TableViewDataSource<String, DistrictRanking>(tableView: tableView) { tableView, indexPath, ranking in
             let cell = tableView.dequeueReusableCell(indexPath: indexPath) as RankingTableViewCell
             cell.viewModel = RankingCellViewModel(apiDistrictRanking: ranking)
             return cell
@@ -62,9 +62,9 @@ class DistrictRankingsViewController: TBASearchableTableViewController, Refresha
         applyRankings(allRankings)
     }
 
-    private func applyRankings(_ rankings: [Components.Schemas.DistrictRanking]) {
+    private func applyRankings(_ rankings: [DistrictRanking]) {
         let query = searchController.searchBar.text?.lowercased() ?? ""
-        let filtered: [Components.Schemas.DistrictRanking]
+        let filtered: [DistrictRanking]
         if query.isEmpty {
             filtered = rankings
         } else {
@@ -75,7 +75,7 @@ class DistrictRankingsViewController: TBASearchableTableViewController, Refresha
         }
         let sorted = filtered.sorted { $0.rank < $1.rank }
 
-        var snapshot = NSDiffableDataSourceSnapshot<String, Components.Schemas.DistrictRanking>()
+        var snapshot = NSDiffableDataSourceSnapshot<String, DistrictRanking>()
         snapshot.appendSections([""])
         snapshot.appendItems(sorted, toSection: "")
         dataSource.apply(snapshot, animatingDifferences: false)

--- a/the-blue-alliance-ios/ViewControllers/Districts/District/DistrictViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/District/DistrictViewController.swift
@@ -5,7 +5,7 @@ import UIKit
 
 class DistrictViewController: ContainerViewController {
 
-    private(set) var district: Components.Schemas.District
+    private(set) var district: District
     private let year: Int
     private let myTBA: MyTBA
     private let myTBAStores: MyTBAStores
@@ -20,7 +20,7 @@ class DistrictViewController: ContainerViewController {
 
     // MARK: - Init
 
-    init(district: Components.Schemas.District, year: Int? = nil, myTBA: MyTBA, myTBAStores: MyTBAStores, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
+    init(district: District, year: Int? = nil, myTBA: MyTBA, myTBAStores: MyTBAStores, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
         self.district = district
         // District keys look like `2023fim` — year is the first 4 chars.
         let parsedYear = year ?? Int(district.key.prefix(4)) ?? statusService.currentSeason
@@ -69,12 +69,12 @@ class DistrictViewController: ContainerViewController {
 
 extension DistrictViewController: EventsListViewControllerDelegate {
 
-    func eventSelected(_ event: Components.Schemas.Event) {
+    func eventSelected(_ event: Event) {
         let eventViewController = EventViewController(eventKey: event.key, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, myTBA: myTBA, myTBAStores: myTBAStores, dependencies: dependencies)
         self.navigationController?.pushViewController(eventViewController, animated: true)
     }
 
-    func title(for event: Components.Schemas.Event) -> String? {
+    func title(for event: Event) -> String? {
         "\(event.weekString) Events"
     }
 
@@ -91,7 +91,7 @@ extension DistrictViewController: TeamsListViewControllerDelegate {
 
 extension DistrictViewController: DistrictRankingsViewControllerDelegate {
 
-    func districtRankingSelected(_ ranking: Components.Schemas.DistrictRanking) {
+    func districtRankingSelected(_ ranking: DistrictRanking) {
         let teamAtDistrictViewController = TeamAtDistrictViewController(ranking: ranking, district: district, year: year, myTBA: myTBA, myTBAStores: myTBAStores, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
         self.navigationController?.pushViewController(teamAtDistrictViewController, animated: true)
     }

--- a/the-blue-alliance-ios/ViewControllers/Districts/District/Team@District/DistrictBreakdownViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/District/Team@District/DistrictBreakdownViewController.swift
@@ -6,11 +6,11 @@ class DistrictBreakdownViewController: TBATableViewController, Refreshable, Stat
 
     private let teamKey: String
     private let districtKey: String
-    private var ranking: Components.Schemas.DistrictRanking
+    private var ranking: DistrictRanking
 
     // MARK: - Init
 
-    init(ranking: Components.Schemas.DistrictRanking, districtKey: String, dependencies: Dependencies) {
+    init(ranking: DistrictRanking, districtKey: String, dependencies: Dependencies) {
         self.ranking = ranking
         self.teamKey = ranking.teamKey
         self.districtKey = districtKey
@@ -32,7 +32,7 @@ class DistrictBreakdownViewController: TBATableViewController, Refreshable, Stat
 
     // MARK: Table View Data Source
 
-    private var eventPoints: [Components.Schemas.DistrictRanking.EventPointsPayloadPayload] {
+    private var eventPoints: [DistrictRanking.EventPointsPayloadPayload] {
         ranking.eventPoints ?? []
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Districts/District/Team@District/DistrictTeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/District/Team@District/DistrictTeamSummaryViewController.swift
@@ -10,13 +10,13 @@ class DistrictTeamSummaryViewController: TBATableViewController, Refreshable, St
 
     private let teamKey: String
     private let districtKey: String
-    private var ranking: Components.Schemas.DistrictRanking
+    private var ranking: DistrictRanking
 
     weak var delegate: DistrictTeamSummaryViewControllerDelegate?
 
     // MARK: Init
 
-    init(ranking: Components.Schemas.DistrictRanking, districtKey: String, dependencies: Dependencies) {
+    init(ranking: DistrictRanking, districtKey: String, dependencies: Dependencies) {
         self.ranking = ranking
         self.teamKey = ranking.teamKey
         self.districtKey = districtKey
@@ -38,7 +38,7 @@ class DistrictTeamSummaryViewController: TBATableViewController, Refreshable, St
 
     // MARK: - Table view data source
 
-    private var eventPoints: [Components.Schemas.DistrictRanking.EventPointsPayloadPayload] {
+    private var eventPoints: [DistrictRanking.EventPointsPayloadPayload] {
         ranking.eventPoints ?? []
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Districts/District/Team@District/TeamAtDistrictViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/District/Team@District/TeamAtDistrictViewController.swift
@@ -9,7 +9,7 @@ class TeamAtDistrictViewController: ContainerViewController {
     private let teamKey: String
     private let districtKey: String
     private let year: Int
-    private var ranking: Components.Schemas.DistrictRanking
+    private var ranking: DistrictRanking
 
     let myTBA: MyTBA
     let myTBAStores: MyTBAStores
@@ -22,7 +22,7 @@ class TeamAtDistrictViewController: ContainerViewController {
 
     // MARK: Init
 
-    init(ranking: Components.Schemas.DistrictRanking, district: Components.Schemas.District, year: Int, myTBA: MyTBA, myTBAStores: MyTBAStores, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
+    init(ranking: DistrictRanking, district: District, year: Int, myTBA: MyTBA, myTBAStores: MyTBAStores, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
         self.ranking = ranking
         self.teamKey = ranking.teamKey
         self.districtKey = district.key

--- a/the-blue-alliance-ios/ViewControllers/Districts/DistrictsContainerViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/DistrictsContainerViewController.swift
@@ -89,7 +89,7 @@ extension DistrictsContainerViewController: SelectTableViewControllerDelegate {
 
 extension DistrictsContainerViewController: DistrictsViewControllerDelegate {
 
-    func districtSelected(_ district: Components.Schemas.District) {
+    func districtSelected(_ district: District) {
         // Show detail wrapped in a UINavigationController for our split view controller
         let districtViewController = DistrictViewController(district: district, myTBA: myTBA, myTBAStores: myTBAStores, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
         if let splitViewController = splitViewController {

--- a/the-blue-alliance-ios/ViewControllers/Districts/DistrictsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Districts/DistrictsViewController.swift
@@ -3,7 +3,7 @@ import TBAAPI
 import UIKit
 
 protocol DistrictsViewControllerDelegate: AnyObject {
-    func districtSelected(_ district: Components.Schemas.District)
+    func districtSelected(_ district: District)
 }
 
 class DistrictsViewController: TBATableViewController, Refreshable, Stateful {
@@ -15,8 +15,8 @@ class DistrictsViewController: TBATableViewController, Refreshable, Stateful {
         }
     }
 
-    private var districts: [Components.Schemas.District] = []
-    private var dataSource: TableViewDataSource<String, Components.Schemas.District>!
+    private var districts: [District] = []
+    private var dataSource: TableViewDataSource<String, District>!
 
     // MARK: - Init
 
@@ -49,7 +49,7 @@ class DistrictsViewController: TBATableViewController, Refreshable, Stateful {
     // MARK: Table View Data Source
 
     private func setupDataSource() {
-        dataSource = TableViewDataSource<String, Components.Schemas.District>(tableView: tableView) { tableView, indexPath, district in
+        dataSource = TableViewDataSource<String, District>(tableView: tableView) { tableView, indexPath, district in
             let cell = tableView.dequeueReusableCell(indexPath: indexPath) as BasicTableViewCell
             cell.textLabel?.text = district.displayName
             cell.accessoryType = .disclosureIndicator
@@ -59,11 +59,11 @@ class DistrictsViewController: TBATableViewController, Refreshable, Stateful {
         dataSource.delegate = self
     }
 
-    private func apply(_ districts: [Components.Schemas.District]) {
+    private func apply(_ districts: [District]) {
         let sorted = districts.sorted { $0.displayName < $1.displayName }
         self.districts = sorted
 
-        var snapshot = NSDiffableDataSourceSnapshot<String, Components.Schemas.District>()
+        var snapshot = NSDiffableDataSourceSnapshot<String, District>()
         snapshot.appendSections([""])
         snapshot.appendItems(sorted, toSection: "")
         dataSource.apply(snapshot, animatingDifferences: false)

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventAlliancesViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventAlliancesViewController.swift
@@ -6,7 +6,7 @@ import UIKit
 
 class EventAlliancesContainerViewController: ContainerViewController {
 
-    private(set) var event: Components.Schemas.Event
+    private(set) var event: Event
     private let myTBA: MyTBA
     private let myTBAStores: MyTBAStores
     private let pasteboard: UIPasteboard?
@@ -18,7 +18,7 @@ class EventAlliancesContainerViewController: ContainerViewController {
 
     // MARK: - Init
 
-    init(event: Components.Schemas.Event, myTBA: MyTBA, myTBAStores: MyTBAStores, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
+    init(event: Event, myTBA: MyTBA, myTBAStores: MyTBAStores, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
         self.event = event
         self.myTBA = myTBA
         self.myTBAStores = myTBAStores
@@ -67,7 +67,7 @@ protocol EventAlliancesViewControllerDelegate: AnyObject {
 private class EventAlliancesViewController: TBATableViewController, Refreshable, Stateful {
 
     private let eventKey: String
-    private var alliances: [Components.Schemas.EliminationAlliance] = []
+    private var alliances: [EliminationAlliance] = []
 
     weak var delegate: EventAlliancesViewControllerDelegate?
 

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventAwardsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventAwardsViewController.swift
@@ -6,7 +6,7 @@ import UIKit
 
 class EventAwardsContainerViewController: ContainerViewController {
 
-    private(set) var event: Components.Schemas.Event
+    private(set) var event: Event
     private let myTBA: MyTBA
     private let myTBAStores: MyTBAStores
     private let pasteboard: UIPasteboard?
@@ -16,7 +16,7 @@ class EventAwardsContainerViewController: ContainerViewController {
 
     // MARK: - Init
 
-    init(event: Components.Schemas.Event, teamKey: String? = nil, myTBA: MyTBA, myTBAStores: MyTBAStores, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
+    init(event: Event, teamKey: String? = nil, myTBA: MyTBA, myTBAStores: MyTBAStores, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
         self.event = event
         self.myTBA = myTBA
         self.myTBAStores = myTBAStores
@@ -69,8 +69,8 @@ class EventAwardsViewController: TBATableViewController, Refreshable, Stateful {
     private let eventKey: String
     private let teamKey: String?
 
-    private var dataSource: TableViewDataSource<String, Components.Schemas.Award>!
-    private var awards: [Components.Schemas.Award] = []
+    private var dataSource: TableViewDataSource<String, Award>!
+    private var awards: [Award] = []
 
     // MARK: - Init
 
@@ -98,7 +98,7 @@ class EventAwardsViewController: TBATableViewController, Refreshable, Stateful {
     // MARK: Table View Data Source
 
     private func setupDataSource() {
-        dataSource = TableViewDataSource<String, Components.Schemas.Award>(tableView: tableView) { [weak self] tableView, indexPath, award in
+        dataSource = TableViewDataSource<String, Award>(tableView: tableView) { [weak self] tableView, indexPath, award in
             let cell = tableView.dequeueReusableCell(indexPath: indexPath) as AwardTableViewCell
             cell.selectionStyle = .none
             cell.viewModel = AwardCellViewModel(award: award)
@@ -112,8 +112,8 @@ class EventAwardsViewController: TBATableViewController, Refreshable, Stateful {
         dataSource.delegate = self
     }
 
-    private func applyAwards(_ awards: [Components.Schemas.Award]) {
-        let filtered: [Components.Schemas.Award]
+    private func applyAwards(_ awards: [Award]) {
+        let filtered: [Award]
         if let teamKey {
             filtered = awards.filter { $0.recipientList.contains(where: { $0.teamKey == teamKey }) }
         } else {
@@ -122,7 +122,7 @@ class EventAwardsViewController: TBATableViewController, Refreshable, Stateful {
         let sorted = filtered.sorted { $0.awardType < $1.awardType }
         self.awards = sorted
 
-        var snapshot = NSDiffableDataSourceSnapshot<String, Components.Schemas.Award>()
+        var snapshot = NSDiffableDataSourceSnapshot<String, Award>()
         snapshot.appendSections([""])
         snapshot.appendItems(sorted, toSection: "")
         dataSource.apply(snapshot, animatingDifferences: false)

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventDistrictPointsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventDistrictPointsViewController.swift
@@ -6,7 +6,7 @@ import UIKit
 
 class EventDistrictPointsContainerViewController: ContainerViewController {
 
-    private(set) var event: Components.Schemas.Event
+    private(set) var event: Event
     private let myTBA: MyTBA
     private let myTBAStores: MyTBAStores
     private let pasteboard: UIPasteboard?
@@ -16,7 +16,7 @@ class EventDistrictPointsContainerViewController: ContainerViewController {
 
     // MARK: - Init
 
-    init(event: Components.Schemas.Event, myTBA: MyTBA, myTBAStores: MyTBAStores, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
+    init(event: Event, myTBA: MyTBA, myTBAStores: MyTBAStores, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
         self.event = event
         self.myTBA = myTBA
         self.myTBAStores = myTBAStores
@@ -118,7 +118,7 @@ private class EventDistrictPointsViewController: TBATableViewController, Refresh
         dataSource.delegate = self
     }
 
-    private func apply(points: Components.Schemas.EventDistrictPoints?) {
+    private func apply(points: EventDistrictPoints?) {
         let sortedRows: [TeamDistrictPointsRow]
         if let dict = points?.points.additionalProperties {
             sortedRows = dict

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventInfoViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventInfoViewController.swift
@@ -19,7 +19,7 @@ private enum EventInfoSection: Int {
 
 private enum EventInfoItem: Hashable {
     case title
-    case webcast(Components.Schemas.Webcast)
+    case webcast(Webcast)
     case alliances
     case districtPoints
     case insights
@@ -37,7 +37,7 @@ class EventInfoViewController: TBATableViewController, Refreshable, Stateful {
 
     // Loaded from TBAAPI in `refresh()`. Until it's loaded the only row we
     // can render is the title placeholder.
-    private var event: Components.Schemas.Event?
+    private var event: Event?
 
     private var dataSource: TableViewDataSource<EventInfoSection, EventInfoItem>!
 

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventRankingsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventRankingsViewController.swift
@@ -3,7 +3,7 @@ import TBAAPI
 import UIKit
 
 protocol EventRankingsViewControllerDelegate: AnyObject {
-    func rankingSelected(_ ranking: Components.Schemas.EventRanking.RankingsPayloadPayload)
+    func rankingSelected(_ ranking: EventRanking.RankingsPayloadPayload)
 }
 
 class EventRankingsViewController: TBATableViewController, Refreshable, Stateful {
@@ -12,10 +12,10 @@ class EventRankingsViewController: TBATableViewController, Refreshable, Stateful
 
     private let eventKey: String
 
-    private var dataSource: TableViewDataSource<String, Components.Schemas.EventRanking.RankingsPayloadPayload>!
-    private var rankings: [Components.Schemas.EventRanking.RankingsPayloadPayload] = []
-    private var extraStatsInfo: [Components.Schemas.EventRanking.ExtraStatsInfoPayloadPayload] = []
-    private var sortOrderInfo: [Components.Schemas.EventRanking.SortOrderInfoPayloadPayload] = []
+    private var dataSource: TableViewDataSource<String, EventRanking.RankingsPayloadPayload>!
+    private var rankings: [EventRanking.RankingsPayloadPayload] = []
+    private var extraStatsInfo: [EventRanking.ExtraStatsInfoPayloadPayload] = []
+    private var sortOrderInfo: [EventRanking.SortOrderInfoPayloadPayload] = []
 
     // MARK: - Init
 
@@ -48,7 +48,7 @@ class EventRankingsViewController: TBATableViewController, Refreshable, Stateful
     // MARK: Table View Data Source
 
     private func setupDataSource() {
-        dataSource = TableViewDataSource<String, Components.Schemas.EventRanking.RankingsPayloadPayload>(tableView: tableView) { [weak self] tableView, indexPath, ranking in
+        dataSource = TableViewDataSource<String, EventRanking.RankingsPayloadPayload>(tableView: tableView) { [weak self] tableView, indexPath, ranking in
             let cell = tableView.dequeueReusableCell(indexPath: indexPath) as RankingTableViewCell
             let detail = self?.rankingInfoString(for: ranking)
             cell.viewModel = RankingCellViewModel(apiRanking: ranking, detailText: detail)
@@ -58,14 +58,14 @@ class EventRankingsViewController: TBATableViewController, Refreshable, Stateful
         dataSource.delegate = self
     }
 
-    private func applyRanking(_ response: Components.Schemas.EventRanking?) {
+    private func applyRanking(_ response: EventRanking?) {
         let rankings = response?.rankings ?? []
         let sorted = rankings.sorted { $0.rank < $1.rank }
         self.rankings = sorted
         self.extraStatsInfo = response?.extraStatsInfo ?? []
         self.sortOrderInfo = response?.sortOrderInfo ?? []
 
-        var snapshot = NSDiffableDataSourceSnapshot<String, Components.Schemas.EventRanking.RankingsPayloadPayload>()
+        var snapshot = NSDiffableDataSourceSnapshot<String, EventRanking.RankingsPayloadPayload>()
         snapshot.appendSections([""])
         snapshot.appendItems(sorted, toSection: "")
         dataSource.apply(snapshot, animatingDifferences: false)
@@ -73,7 +73,7 @@ class EventRankingsViewController: TBATableViewController, Refreshable, Stateful
 
     // MARK: Ranking info string
 
-    private func rankingInfoString(for ranking: Components.Schemas.EventRanking.RankingsPayloadPayload) -> String? {
+    private func rankingInfoString(for ranking: EventRanking.RankingsPayloadPayload) -> String? {
         var parts: [String] = []
         parts.append(contentsOf: Self.formattedPairs(values: ranking.extraStats, info: extraStatsInfo.map { (name: $0.name, precision: Int($0.precision)) }))
         parts.append(contentsOf: Self.formattedPairs(values: ranking.sortOrders ?? [], info: sortOrderInfo.map { (name: $0.name, precision: $0.precision) }))

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/EventViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/EventViewController.swift
@@ -14,7 +14,7 @@ class EventViewController: MyTBAContainerViewController, EventStatusSubscribable
 
     // Loaded from TBAAPI after init; used for nav title + for the event struct
     // passed to the detail container VCs (alliances/awards/etc.).
-    private var event: Components.Schemas.Event?
+    private var event: Event?
 
     private(set) var infoViewController: EventInfoViewController
     private(set) var teamsViewController: EventTeamsViewController
@@ -138,7 +138,7 @@ extension EventViewController: TeamsListViewControllerDelegate {
 
 extension EventViewController: EventRankingsViewControllerDelegate {
 
-    func rankingSelected(_ ranking: Components.Schemas.EventRanking.RankingsPayloadPayload) {
+    func rankingSelected(_ ranking: EventRanking.RankingsPayloadPayload) {
         pushTeamAtEvent(teamKey: ranking.teamKey)
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/Stats/EventInsightsContainerViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/Stats/EventInsightsContainerViewController.swift
@@ -6,7 +6,7 @@ import UIKit
 
 class EventInsightsContainerViewController: ContainerViewController {
 
-    private(set) var event: Components.Schemas.Event
+    private(set) var event: Event
     private let myTBA: MyTBA
     private let myTBAStores: MyTBAStores
     private let pasteboard: UIPasteboard?
@@ -18,7 +18,7 @@ class EventInsightsContainerViewController: ContainerViewController {
 
     // MARK: - Init
 
-    init(event: Components.Schemas.Event, myTBA: MyTBA, myTBAStores: MyTBAStores, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
+    init(event: Event, myTBA: MyTBA, myTBAStores: MyTBAStores, pasteboard: UIPasteboard? = nil, photoLibrary: PHPhotoLibrary? = nil, statusService: StatusService, urlOpener: URLOpener, dependencies: Dependencies) {
         self.event = event
         self.myTBA = myTBA
         self.myTBAStores = myTBAStores

--- a/the-blue-alliance-ios/ViewControllers/Events/Event/Stats/EventTeamStatsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/Event/Stats/EventTeamStatsViewController.swift
@@ -102,7 +102,7 @@ class EventTeamStatsTableViewController: TBATableViewController, Refreshable, St
         dataSource.delegate = self
     }
 
-    private func apply(oprs response: Components.Schemas.EventOPRs?) {
+    private func apply(oprs response: EventOPRs?) {
         let oprs = response?.oprs?.additionalProperties ?? [:]
         let dprs = response?.dprs?.additionalProperties ?? [:]
         let ccwms = response?.ccwms?.additionalProperties ?? [:]

--- a/the-blue-alliance-ios/ViewControllers/Events/EventsContainerViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/EventsContainerViewController.swift
@@ -68,7 +68,7 @@ class EventsContainerViewController: ContainerViewController {
 
     // MARK: - Private Methods
 
-    private static func eventsTitle(_ event: Components.Schemas.Event?) -> String {
+    private static func eventsTitle(_ event: Event?) -> String {
         if let event = event {
             return "\(event.weekString) Events"
         } else {
@@ -98,7 +98,7 @@ extension EventsContainerViewController: NavigationTitleDelegate {
 
 extension EventsContainerViewController: YearSelectViewControllerDelegate {
 
-    func weekEventSelected(year: Int, weekEvent: Components.Schemas.Event) {
+    func weekEventSelected(year: Int, weekEvent: Event) {
         self.year = year
         eventsViewController.weekEvent = weekEvent
     }
@@ -119,7 +119,7 @@ extension EventsContainerViewController: SearchContainer, SearchContainerDelegat
 
 extension EventsContainerViewController: EventsListViewControllerDelegate {
 
-    func eventSelected(_ event: Components.Schemas.Event) {
+    func eventSelected(_ event: Event) {
         let eventViewController = EventViewController(eventKey: event.key,
                                                       pasteboard: pasteboard,
                                                       photoLibrary: photoLibrary,

--- a/the-blue-alliance-ios/ViewControllers/Events/EventsListViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/EventsListViewController.swift
@@ -2,17 +2,17 @@ import TBAAPI
 import UIKit
 
 protocol EventsListViewControllerDelegate: AnyObject {
-    func eventSelected(_ event: Components.Schemas.Event)
-    func title(for event: Components.Schemas.Event) -> String?
+    func eventSelected(_ event: Event)
+    func title(for event: Event) -> String?
 }
 
 extension EventsListViewControllerDelegate {
-    func title(for event: Components.Schemas.Event) -> String? { nil }
+    func title(for event: Event) -> String? { nil }
 }
 
 class EventsListViewController: TBATableViewController, Refreshable, Stateful {
 
-    typealias APIEvent = Components.Schemas.Event
+    typealias APIEvent = Event
 
     weak var delegate: EventsListViewControllerDelegate?
 

--- a/the-blue-alliance-ios/ViewControllers/Events/YearSelectViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Events/YearSelectViewController.swift
@@ -4,14 +4,14 @@ import TBAAPI
 import UIKit
 
 protocol YearSelectViewControllerDelegate: AnyObject {
-    func weekEventSelected(year: Int, weekEvent: Components.Schemas.Event)
+    func weekEventSelected(year: Int, weekEvent: Event)
 }
 
 class YearSelectViewController: ContainerViewController {
 
     private(set) var year: Int
     private(set) var years: [Int]
-    private(set) var week: Components.Schemas.Event?
+    private(set) var week: Event?
 
     private let selectViewController: SelectTableViewController<YearSelectViewController>
     private var eventWeekSelectViewController: EventWeekSelectViewController?
@@ -24,7 +24,7 @@ class YearSelectViewController: ContainerViewController {
 
     // MARK: - Init
 
-    init(year: Int, years: [Int], week: Components.Schemas.Event?, dependencies: Dependencies) {
+    init(year: Int, years: [Int], week: Event?, dependencies: Dependencies) {
         self.year = year
         self.years = years
         self.week = week
@@ -106,7 +106,7 @@ private class EventWeekSelectViewController: ContainerViewController {
 
     weak var delegate: YearSelectViewControllerDelegate?
 
-    init(year: Int, week: Components.Schemas.Event?, dependencies: Dependencies) {
+    init(year: Int, week: Event?, dependencies: Dependencies) {
         self.year = year
 
         selectViewController = WeeksSelectTableViewController(year: year,
@@ -138,7 +138,7 @@ private class EventWeekSelectViewController: ContainerViewController {
 
 extension EventWeekSelectViewController: SelectTableViewControllerDelegate {
 
-    typealias OptionType = Components.Schemas.Event
+    typealias OptionType = Event
 
     func optionSelected(_ option: OptionType) {
         delegate?.weekEventSelected(year: year, weekEvent: option)
@@ -155,7 +155,7 @@ private class WeeksSelectTableViewController: SelectTableViewController<EventWee
     private let year: Int
     fileprivate var hasRefreshed: Bool = false
 
-    init(year: Int, current: Components.Schemas.Event?, options: [Components.Schemas.Event], dependencies: Dependencies) {
+    init(year: Int, current: Event?, options: [Event], dependencies: Dependencies) {
         self.year = year
         super.init(current: current, options: options, dependencies: dependencies)
     }

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchBreakdownViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchBreakdownViewController.swift
@@ -31,7 +31,7 @@ class MatchBreakdownViewController: TBATableViewController, Refreshable, Statefu
     private let year: Int
     private let breakdownConfigurator: MatchBreakdownConfigurator.Type?
 
-    private var match: Components.Schemas.Match?
+    private var match: Match?
 
     private var dataSource: TableViewDataSource<String?, BreakdownRow>!
 
@@ -94,7 +94,7 @@ class MatchBreakdownViewController: TBATableViewController, Refreshable, Statefu
         dataSource.statefulDelegate = self
     }
 
-    func apply(match: Components.Schemas.Match) {
+    func apply(match: Match) {
         self.match = match
         configureDataSource(match.breakdownDict)
     }

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchInfoViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchInfoViewController.swift
@@ -9,7 +9,7 @@ class MatchInfoViewController: TBAViewController, Refreshable {
     private let matchKey: String
     private let teamKey: String?
 
-    private var match: Components.Schemas.Match?
+    private var match: Match?
 
     // MARK: - UI
 
@@ -115,7 +115,7 @@ class MatchInfoViewController: TBAViewController, Refreshable {
         view.backgroundColor = .systemBackground
     }
 
-    func apply(match: Components.Schemas.Match) {
+    func apply(match: Match) {
         self.match = match
         updateInterface()
     }
@@ -150,7 +150,7 @@ class MatchInfoViewController: TBAViewController, Refreshable {
         }
     }
 
-    private static func playerView(for video: Components.Schemas.Match.VideosPayloadPayload) -> PlayerView {
+    private static func playerView(for video: Match.VideosPayloadPayload) -> PlayerView {
         let playerView = PlayerView(playable: MatchVideoPlayable(video: video))
         playerView.autoConstrainAttribute(.width, to: .height, of: playerView, withMultiplier: (16.0/9.0))
         return playerView
@@ -189,7 +189,7 @@ class MatchInfoViewController: TBAViewController, Refreshable {
 // contract that `PlayerView` consumes. Only YouTube videos are playable —
 // the old `MatchVideo.youtubeKey` mapped the same way.
 private struct MatchVideoPlayable: Playable {
-    let video: Components.Schemas.Match.VideosPayloadPayload
+    let video: Match.VideosPayloadPayload
 
     var youtubeKey: String? {
         video._type == "youtube" ? video.key : nil

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchViewController.swift
@@ -8,7 +8,7 @@ class MatchViewController: MyTBAContainerViewController {
     private let matchKey: String
     private let teamKey: String?
 
-    private var match: Components.Schemas.Match?
+    private var match: Match?
 
     private(set) var infoViewController: MatchInfoViewController
     private let breakdownViewController: MatchBreakdownViewController

--- a/the-blue-alliance-ios/ViewControllers/Match/MatchesViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Match/MatchesViewController.swift
@@ -18,9 +18,9 @@ class MatchesViewController: TBATableViewController, Refreshable, Stateful {
     private var myTBA: MyTBA
     private let favoritesStore: FavoritesStore
 
-    private var dataSource: TableViewDataSource<String, Components.Schemas.Match>!
+    private var dataSource: TableViewDataSource<String, Match>!
 
-    private var allMatches: [Components.Schemas.Match] = []
+    private var allMatches: [Match] = []
     private var favoriteTeamKeys: [String] = []
 
     lazy var matchQueryBarButtonItem: UIBarButtonItem = {
@@ -68,7 +68,7 @@ class MatchesViewController: TBATableViewController, Refreshable, Stateful {
     // MARK: Table View Data Source
 
     private func setupDataSource() {
-        dataSource = TableViewDataSource<String, Components.Schemas.Match>(tableView: tableView) { [weak self] tableView, indexPath, match in
+        dataSource = TableViewDataSource<String, Match>(tableView: tableView) { [weak self] tableView, indexPath, match in
             let cell = tableView.dequeueReusableCell(indexPath: indexPath) as MatchTableViewCell
 
             var baseTeamKeys: Set<String> = Set()
@@ -85,14 +85,14 @@ class MatchesViewController: TBATableViewController, Refreshable, Stateful {
         dataSource.delegate = self
     }
 
-    private func applyMatches(_ matches: [Components.Schemas.Match]) {
+    private func applyMatches(_ matches: [Match]) {
         let filtered = matches.filter(for: teamKey, favoriteTeamKeys: query.filter.favorites ? favoriteTeamKeys : nil)
         let sorted = filtered.sorted(ascending: !query.sort.reverse)
 
-        var snapshot = NSDiffableDataSourceSnapshot<String, Components.Schemas.Match>()
+        var snapshot = NSDiffableDataSourceSnapshot<String, Match>()
         // Group by comp-level string so sections mirror the old FRC behavior.
         var sectionOrder: [String] = []
-        var grouped: [String: [Components.Schemas.Match]] = [:]
+        var grouped: [String: [Match]] = [:]
         for match in sorted {
             let key = match.compLevelString
             if grouped[key] == nil {
@@ -182,8 +182,8 @@ extension MatchesViewController {
     // Placeholder so `MatchesViewControllerQueryable`'s `showFilter()` still compiles.
 }
 
-private extension Array where Element == Components.Schemas.Match {
-    func filter(for teamKey: String?, favoriteTeamKeys: [String]?) -> [Components.Schemas.Match] {
+private extension Array where Element == Match {
+    func filter(for teamKey: String?, favoriteTeamKeys: [String]?) -> [Match] {
         var results = self
         if let teamKey {
             results = results.filter { $0.allTeamKeys.contains(teamKey) }
@@ -197,7 +197,7 @@ private extension Array where Element == Components.Schemas.Match {
         return results
     }
 
-    func sorted(ascending: Bool) -> [Components.Schemas.Match] {
+    func sorted(ascending: Bool) -> [Match] {
         sorted { lhs, rhs in
             if lhs.compLevelSortOrder != rhs.compLevelSortOrder {
                 return ascending

--- a/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/MyTBA/MyTBATableViewController.swift
@@ -63,9 +63,9 @@ class MyTBATableViewController: TBATableViewController, NotificationObservable {
 
     private var dataSource: TableViewDataSource<MyTBASection, MyTBAItem>!
 
-    private var eventsCache: [String: Components.Schemas.Event] = [:]
-    private var teamsCache: [String: Components.Schemas.Team] = [:]
-    private var matchesCache: [String: Components.Schemas.Match] = [:]
+    private var eventsCache: [String: Event] = [:]
+    private var teamsCache: [String: Team] = [:]
+    private var matchesCache: [String: Match] = [:]
 
     // MARK: Init
 

--- a/the-blue-alliance-ios/ViewControllers/Search/SearchViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Search/SearchViewController.swift
@@ -45,7 +45,7 @@ class SearchViewController: TBATableViewController {
         didSet { updateSnapshot() }
     }
 
-    private var index: Components.Schemas.SearchIndex?
+    private var index: SearchIndex?
     private var dataSource: TableViewDataSource<SearchSection, SearchItem>!
 
     init(dependencies: Dependencies) {
@@ -151,12 +151,12 @@ class SearchViewController: TBATableViewController {
         dataSource.apply(snapshot, animatingDifferences: false)
     }
 
-    private func matches(team: Components.Schemas.SearchIndex.TeamsPayloadPayload, query: String) -> Bool {
+    private func matches(team: SearchIndex.TeamsPayloadPayload, query: String) -> Bool {
         let number = TeamKey.trimFRCPrefix(team.key)
         return number.hasPrefix(query) || team.nickname.lowercased().contains(query) || team.key.lowercased().contains(query)
     }
 
-    private func matches(event: Components.Schemas.SearchIndex.EventsPayloadPayload, query: String) -> Bool {
+    private func matches(event: SearchIndex.EventsPayloadPayload, query: String) -> Bool {
         event.name.lowercased().contains(query) || event.key.lowercased().contains(query)
     }
 

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamStatsViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamStatsViewController.swift
@@ -87,7 +87,7 @@ private struct TeamStats {
     let dpr: Float?
     let ccwm: Float?
 
-    init?(teamKey: String, oprs: Components.Schemas.EventOPRs?) {
+    init?(teamKey: String, oprs: EventOPRs?) {
         guard let oprs else { return nil }
         let o = oprs.oprs?.additionalProperties[teamKey]
         let d = oprs.dprs?.additionalProperties[teamKey]

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/Team@Event/TeamSummaryViewController.swift
@@ -17,14 +17,14 @@ private enum TeamSummarySection: Int {
 }
 
 private enum TeamSummaryItem: Hashable {
-    case teamInfo(team: Components.Schemas.Team)
+    case teamInfo(team: Team)
     case status(status: String)
     case rank(rank: Int, total: Int)
     case record(wins: Int, losses: Int, ties: Int, dqs: Int? = nil)
     case average(average: Double)
     case breakdown(rankingInfo: String)
     case alliance(allianceStatus: String)
-    case match(match: Components.Schemas.Match, baseTeamKey: String?)
+    case match(match: Match, baseTeamKey: String?)
 }
 
 class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
@@ -34,11 +34,11 @@ class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
     private let teamKey: String
     private let eventKey: String
 
-    private var team: Components.Schemas.Team?
-    private var event: Components.Schemas.Event?
-    private var eventStatus: Components.Schemas.TeamEventStatus?
-    private var nextMatch: Components.Schemas.Match?
-    private var lastMatch: Components.Schemas.Match?
+    private var team: Team?
+    private var event: Event?
+    private var eventStatus: TeamEventStatus?
+    private var nextMatch: Match?
+    private var lastMatch: Match?
 
     private var dataSource: TableViewDataSource<TeamSummarySection, TeamSummaryItem>!
 
@@ -223,7 +223,7 @@ class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
 
     // MARK: - Cells
 
-    private func cellForTeam(_ team: Components.Schemas.Team, in tableView: UITableView, at indexPath: IndexPath) -> UITableViewCell {
+    private func cellForTeam(_ team: Team, in tableView: UITableView, at indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(indexPath: indexPath) as InfoTableViewCell
         cell.viewModel = InfoCellViewModel(nameString: team.displayNickname, subtitleStrings: [team.locationString].compactMap { $0 })
         cell.accessoryType = .disclosureIndicator
@@ -242,7 +242,7 @@ class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
         return cell
     }
 
-    private static func cellForMatch(_ match: Components.Schemas.Match, baseTeamKey: String?, in tableView: UITableView, at indexPath: IndexPath) -> MatchTableViewCell {
+    private static func cellForMatch(_ match: Match, baseTeamKey: String?, in tableView: UITableView, at indexPath: IndexPath) -> MatchTableViewCell {
         let cell = tableView.dequeueReusableCell(indexPath: indexPath) as MatchTableViewCell
         cell.viewModel = MatchViewModel(apiMatch: match, baseTeamKeys: baseTeamKey.map { [$0] } ?? [])
         return cell
@@ -297,12 +297,12 @@ class TeamSummaryViewController: TBATableViewController, Refreshable, Stateful {
                 self.eventStatus = statusResult ?? nil
 
                 // Fetch next/last match if we have keys. Fire in parallel.
-                async let nextTask: Components.Schemas.Match?? = {
-                    guard let key = self.eventStatus?.nextMatchKey else { return Optional<Components.Schemas.Match?>.none }
+                async let nextTask: Match?? = {
+                    guard let key = self.eventStatus?.nextMatchKey else { return Optional<Match?>.none }
                     return try? await dependencies.api.match(key: key)
                 }()
-                async let lastTask: Components.Schemas.Match?? = {
-                    guard let key = self.eventStatus?.lastMatchKey else { return Optional<Components.Schemas.Match?>.none }
+                async let lastTask: Match?? = {
+                    guard let key = self.eventStatus?.lastMatchKey else { return Optional<Match?>.none }
                     return try? await dependencies.api.match(key: key)
                 }()
                 let (nextResult, lastResult) = await (nextTask, lastTask)

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamInfoViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamInfoViewController.swift
@@ -22,7 +22,7 @@ class TeamInfoViewController: TBATableViewController, Refreshable, Stateful {
     private let teamKey: String
     private let urlOpener: URLOpener
 
-    private var team: Components.Schemas.Team?
+    private var team: Team?
 
     private var dataSource: TableViewDataSource<TeamInfoSection, TeamInfoItem>!
 
@@ -55,7 +55,7 @@ class TeamInfoViewController: TBATableViewController, Refreshable, Stateful {
 
     // MARK: - External
 
-    func apply(team: Components.Schemas.Team) {
+    func apply(team: Team) {
         self.team = team
         updateTeamInfo()
     }

--- a/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/Team/TeamViewController.swift
@@ -13,7 +13,7 @@ class TeamViewController: HeaderContainerViewController {
     private let urlOpener: URLOpener
 
     // Loaded from TBAAPI after init. Nil until the async load completes.
-    private var team: Components.Schemas.Team?
+    private var team: Team?
     private var yearsParticipated: [Int] = []
 
     private let teamHeaderView: TeamHeaderView
@@ -182,7 +182,7 @@ extension TeamViewController: SelectTableViewControllerDelegate {
 
 extension TeamViewController: EventsListViewControllerDelegate {
 
-    func eventSelected(_ event: Components.Schemas.Event) {
+    func eventSelected(_ event: Event) {
         let teamAtEventViewController = TeamAtEventViewController(teamKey: teamKey, eventKey: event.key, year: event.year, myTBA: myTBA, myTBAStores: myTBAStores, pasteboard: pasteboard, photoLibrary: photoLibrary, statusService: statusService, urlOpener: urlOpener, dependencies: dependencies)
         self.navigationController?.pushViewController(teamAtEventViewController, animated: true)
     }

--- a/the-blue-alliance-ios/ViewControllers/Teams/TeamsListViewController.swift
+++ b/the-blue-alliance-ios/ViewControllers/Teams/TeamsListViewController.swift
@@ -7,7 +7,7 @@ protocol TeamsListViewControllerDelegate: AnyObject {
 
 class TeamsListViewController: TBASearchableTableViewController, Refreshable, Stateful {
 
-    typealias APITeam = Components.Schemas.Team
+    typealias APITeam = Team
 
     weak var delegate: TeamsListViewControllerDelegate?
 

--- a/the-blue-alliance-ios/ViewElements/Awards/AwardCellViewModel.swift
+++ b/the-blue-alliance-ios/ViewElements/Awards/AwardCellViewModel.swift
@@ -11,7 +11,7 @@ struct AwardCellViewModel {
     let awardName: String?
     let recipients: [Recipient]
 
-    init(award: Components.Schemas.Award) {
+    init(award: Award) {
         awardName = award.name
         recipients = award.recipientList.map { apiRecipient in
             var awardText: [String] = []

--- a/the-blue-alliance-ios/ViewElements/Events/EventAllianceCellViewModel.swift
+++ b/the-blue-alliance-ios/ViewElements/Events/EventAllianceCellViewModel.swift
@@ -7,7 +7,7 @@ struct EventAllianceCellViewModel {
     let allianceName: String
     let picks: [String]
 
-    init(alliance: Components.Schemas.EliminationAlliance, allianceNumber: Int) {
+    init(alliance: EliminationAlliance, allianceNumber: Int) {
         allianceLevel = Self.allianceLevel(status: alliance.status)
         allianceName = alliance.name ?? "Alliance \(allianceNumber)"
         picks = alliance.picks
@@ -17,7 +17,7 @@ struct EventAllianceCellViewModel {
         return allianceLevel != nil
     }
 
-    private static func allianceLevel(status: Components.Schemas.EliminationAlliance.StatusPayload?) -> String? {
+    private static func allianceLevel(status: EliminationAlliance.StatusPayload?) -> String? {
         guard let level = status?.level else { return nil }
         if level == "f", let s = status?.status {
             return s == "won" ? "W" : "F"

--- a/the-blue-alliance-ios/ViewElements/Events/RankingCellViewModel.swift
+++ b/the-blue-alliance-ios/ViewElements/Events/RankingCellViewModel.swift
@@ -11,7 +11,7 @@ struct RankingCellViewModel {
     let detailText: String?
     let wltText: String?
 
-    init(apiDistrictRanking ranking: Components.Schemas.DistrictRanking) {
+    init(apiDistrictRanking ranking: DistrictRanking) {
         self.rankText = "Rank \(ranking.rank)"
         self.teamNumber = Self.teamNumber(from: ranking.teamKey)
         self.teamName = "Team \(self.teamNumber ?? ranking.teamKey)"
@@ -35,7 +35,7 @@ struct RankingCellViewModel {
         self.wltText = nil
     }
 
-    init(apiRanking ranking: Components.Schemas.EventRanking.RankingsPayloadPayload, detailText: String?) {
+    init(apiRanking ranking: EventRanking.RankingsPayloadPayload, detailText: String?) {
         self.rankText = "Rank \(ranking.rank)"
         self.teamNumber = Self.teamNumber(from: ranking.teamKey)
         self.teamName = "Team \(self.teamNumber ?? ranking.teamKey)"

--- a/the-blue-alliance-ios/ViewElements/Info/InfoCellViewModel.swift
+++ b/the-blue-alliance-ios/ViewElements/Info/InfoCellViewModel.swift
@@ -6,7 +6,7 @@ struct InfoCellViewModel {
     let nameString: String
     let subtitleStrings: [String]
 
-    init(event: Components.Schemas.Event) {
+    init(event: Event) {
         nameString = event.name.isEmpty ? event.key : event.name
         subtitleStrings = [event.locationString, event.dateString, event.weekString].compactMap { $0 }
     }

--- a/the-blue-alliance-ios/ViewElements/Match/MatchViewModel.swift
+++ b/the-blue-alliance-ios/ViewElements/Match/MatchViewModel.swift
@@ -40,7 +40,7 @@ struct MatchViewModel {
         return rpCount
     }
 
-    init(apiMatch match: Components.Schemas.Match, baseTeamKeys: [String] = []) {
+    init(apiMatch match: Match, baseTeamKeys: [String] = []) {
         matchName = match.friendlyName
         hasVideos = match.videos.isEmpty
 


### PR DESCRIPTION
Call sites now say `Event`, `Team`, `Match`, etc. instead of the verbose generated `Components.Schemas.*` path. The aliases live in the TBAAPI package (Packages/TBAAPI/Sources/TBAAPI/Extensions/ TypeAliases.swift) as public typealiases, so `import TBAAPI` picks them up across the main app.

Aliased: APIStatus, Award, District, DistrictRanking, Elimination Alliance, Event, EventDistrictPoints, EventInsights, EventOPRs, EventRanking, Match, Media, SearchIndex, Team, TeamEventStatus, Webcast. Nested types (EventRanking.RankingsPayloadPayload etc.) shorten for free since their parent's alias cascades.

This was deferred until Phase 7 landed because each of those names collided with the NSManagedObject subclasses in TBAData — those classes are gone now, so the names are free.